### PR TITLE
iowait may decrease

### DIFF
--- a/lib/proc.cc
+++ b/lib/proc.cc
@@ -426,7 +426,7 @@ struct stat_vals {
     auto delta_stolen = steal - prev.steal;
     auto delta_nice = nice - prev.nice;
     auto delta_interrupt = (irq + softirq) - (prev.irq + prev.softirq);
-    auto delta_wait = iowait - prev.iowait;
+    auto delta_wait = iowait > prev.iowait ? iowait - prev.iowait : 0;
 
     if (delta_total > 0) {
       vals.user = 100.0 * delta_user / delta_total;


### PR DESCRIPTION
The iowait time from /proc/stat is not guaranteed to be a monotonic
counter. In some cases the value will go down. Previously we were
reporting a huge number if that was the case, now we'll just report 0