### PR TITLE
Generate metrics for overlay fs for titus-agent

### DIFF
--- a/lib/disk.cc
+++ b/lib/disk.cc
@@ -55,6 +55,11 @@ std::set<std::string> get_nodev_filesystems(const std::string& prefix) {
 std::vector<MountPoint> Disk::get_mount_points() const noexcept {
   auto unwanted_filesystems = get_nodev_filesystems(path_prefix_);
   unwanted_filesystems.erase("tmpfs");
+#ifdef TITUS_AGENT
+  // for titus we generate metrics for overlay fs
+  // see overlay_stats()
+  unwanted_filesystems.erase("overlay");
+#endif
 
   auto file_name = fmt::format("{}/proc/self/mountinfo", path_prefix_);
   std::ifstream in(file_name);

--- a/lib/proc.cc
+++ b/lib/proc.cc
@@ -92,7 +92,6 @@ void sum_tcp_states(FILE* fp, std::array<int, kConnStates>* connections) noexcep
   if (fgets(line, sizeof line, fp) == nullptr) {
     return;
   }
-  int n = 1;
   while (fgets(line, sizeof line, fp) != nullptr) {
     std::vector<std::string> fields;
     split(line, &fields);
@@ -105,9 +104,7 @@ void sum_tcp_states(FILE* fp, std::array<int, kConnStates>* connections) noexcep
     } else {
       Logger()->info("Ignoring connection state {} for line: {}", state, line);
     }
-    n++;
   }
-  Logger()->debug("Read {} lines from file", n);
 }
 
 using gauge_ptr = std::shared_ptr<atlas::meter::Gauge<double>>;

--- a/test/disk_test.cc
+++ b/test/disk_test.cc
@@ -36,7 +36,9 @@ class TestDisk : public Disk {
 
 TEST(Disk, NodevFS) {
   auto fs = atlasagent::get_nodev_filesystems("./resources");
-  EXPECT_EQ(fs.size(), 25);
+  auto has_overlay = fs.find("overlay") != fs.end();
+  EXPECT_TRUE(has_overlay);
+  EXPECT_EQ(fs.size(), 26);
 }
 
 TEST(Disk, MountPoints) {

--- a/test/resources/proc/filesystems
+++ b/test/resources/proc/filesystems
@@ -31,3 +31,4 @@ nodev	autofs
 nodev	zfs
 nodev	binfmt_misc
 	xfs
+nodev	overlay


### PR DESCRIPTION
Titus uses overlay filesystems for / and it the agent has code specific
for dealing with them. The latest `nodev` change was causing them to be
incorrectly ignored for titus-agent. This change adds them (with tmpfs)
to the whitelist of filesystems that are considered for metrics
collection.