### PR TITLE
Bug fix for titus-filesystem selection

### DIFF
--- a/lib/disk.h
+++ b/lib/disk.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <atlas/meter/id.h>
 #include <contain.h>
+#include "../config.h"
 #include "counters.h"
 #include "quotahelper.h"
 

--- a/test/disk_test.cc
+++ b/test/disk_test.cc
@@ -45,7 +45,19 @@ TEST(Disk, MountPoints) {
   TestRegistry registry;
   TestDisk disk(&registry);
   auto mount_points = disk.get_mount_points();
-  EXPECT_EQ(mount_points.size(), 11);
+  EXPECT_EQ(mount_points.size(), 7);
+
+  disk.set_prefix("./resources2");
+  mount_points = disk.get_mount_points();
+  for (const auto& mp : mount_points) {
+    Logger()->info("{}", mp);
+  }
+#ifdef TITUS_AGENT
+  // titus does not ignore overlay
+  EXPECT_EQ(mount_points.size(), 5);
+#else
+  EXPECT_EQ(mount_points.size(), 4);
+#endif
 }
 
 TEST(Disk, id) {
@@ -79,11 +91,12 @@ TEST(Disk, InterestingMountPoints) {
     std::cerr << mp << "\n";
   }
 
-  ASSERT_EQ(interesting2.size(), 3);
+#ifdef TITUS_AGENT
+  ASSERT_EQ(interesting2.size(), 1);
   EXPECT_EQ(interesting2[0].mount_point, "/");
-  // xvda/xvdb are not particularly useful for titus - should we special case titus?
-  EXPECT_EQ(interesting2[1].device, "/dev/xvdb");
-  EXPECT_EQ(interesting2[2].device, "/dev/xvda");
+#else
+  ASSERT_EQ(interesting2.size(), 0);
+#endif
 }
 
 TEST(Disk, UpdateTitusStats) {

--- a/test/resources2/proc/filesystems
+++ b/test/resources2/proc/filesystems
@@ -31,3 +31,4 @@ nodev	autofs
 nodev	zfs
 nodev	binfmt_misc
 	xfs
+nodev	overlay


### PR DESCRIPTION
Missed the inclusion of config.h, therefore TITUS_DEV was not defined in
disk.cc causing titus to ignore overlay fs.
Ignore filesystems that are not mounted on /
Make sure we add the correct filesystem name to the nodev set.