### PR TITLE
Update to the latest native client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
   - gcc
 env:
   global:
-    - NATIVE_CLIENT_VERSION=v4.0.0
+    - NATIVE_CLIENT_VERSION=v0.4.2
   matrix:
     - TITUS_AGENT="-DTITUS_AGENT=ON .."
     - TITUS_AGENT=""

--- a/lib/disk.cc
+++ b/lib/disk.cc
@@ -126,6 +126,7 @@ std::vector<MountPoint> Disk::filter_interesting_mount_points(
       candidates[key] = &mp;
     }
   }
+  interesting.reserve(candidates.size());
   for (const auto& kv : candidates) {
     interesting.emplace_back(*kv.second);
   }

--- a/lib/proc.cc
+++ b/lib/proc.cc
@@ -1,8 +1,8 @@
 #include "proc.h"
-#include "util.h"
 #include "atlas-helpers.h"
-#include <cstring>
+#include "util.h"
 #include <cinttypes>
+#include <cstring>
 
 namespace atlasagent {
 
@@ -96,7 +96,9 @@ void sum_tcp_states(FILE* fp, std::array<int, kConnStates>* connections) noexcep
     std::vector<std::string> fields;
     split(line, &fields);
     // all lines have at least 12 fields. Just being extra paranoid here:
-    if (fields.size() < 4) continue;
+    if (fields.size() < 4) {
+      continue;
+    }
     const char* st = fields[3].c_str();
     auto state = static_cast<int>(strtol(st, nullptr, 16));
     if (state < kConnStates) {
@@ -318,7 +320,9 @@ bool Proc::is_container() const noexcept {
   }
   char line[1024];
   bool error = std::fgets(line, sizeof line, fp) == nullptr;
-  if (error) return false;
+  if (error) {
+    return false;
+  }
 
   return proc::get_pid_from_sched(line) != 1;
 }
@@ -378,8 +382,9 @@ struct cores_dist_summary {
 
 struct stat_vals {
   static constexpr const char* CPU_STATS_LINE = " %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu";
-  u_long user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice;
-  double total;
+  u_long user{0}, nice{0}, system{0}, idle{0}, iowait{0}, irq{0}, softirq{0}, steal{0}, guest{0},
+      guest_nice{0};
+  double total{NAN};
 
   static stat_vals parse(const char* line) {
     stat_vals result;
@@ -402,18 +407,7 @@ struct stat_vals {
 
   bool is_init() const noexcept { return !std::isnan(total); }
 
-  stat_vals()
-      : user(0),
-        nice(0),
-        system(0),
-        idle(0),
-        iowait(0),
-        irq(0),
-        softirq(0),
-        steal(0),
-        guest(0),
-        guest_nice(0),
-        total(NAN) {}
+  stat_vals() = default;
 
   cpu_gauge_vals compute_vals(const stat_vals& prev) const noexcept {
     cpu_gauge_vals vals{};

--- a/lib/util.cc
+++ b/lib/util.cc
@@ -38,7 +38,7 @@ void parse_kv_from_file(const std::string& prefix, const char* fn,
   }
 }
 
-void split(const char* line, std::vector<std::string>* res) noexcept {
+void split(const char* line, std::vector<std::string>* fields) noexcept {
   const char* p = line;
   const char* end = line + strlen(line);
   char field[256];
@@ -59,7 +59,7 @@ void split(const char* line, std::vector<std::string>* res) noexcept {
       ++p;
     }
     field[i] = '\0';
-    res->emplace_back(field);
+    fields->emplace_back(field);
     i = 0;
   }
 }

--- a/test/cgroup_test.cc
+++ b/test/cgroup_test.cc
@@ -5,10 +5,12 @@
 #include <gtest/gtest.h>
 
 using namespace atlasagent;
+using atlas::meter::ManualClock;
 
 // TODO: verify values
 TEST(CGroup, ParseCpu) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   registry.SetWall(1000);
   CGroup cGroup{&registry, "./resources"};
 
@@ -30,7 +32,8 @@ TEST(CGroup, ParseCpu) {
 }
 
 TEST(CGroup, ParseMemory) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   registry.SetWall(1000);
   CGroup cGroup{&registry, "./resources"};
 

--- a/test/disk_test.cc
+++ b/test/disk_test.cc
@@ -11,6 +11,7 @@ std::unordered_set<std::string> get_nodev_filesystems(const std::string& prefix)
 }  // namespace atlasagent
 
 using namespace atlasagent;
+using atlas::meter::ManualClock;
 using atlas::meter::Tags;
 
 class TestDisk : public Disk {
@@ -43,7 +44,8 @@ TEST(Disk, NodevFS) {
 }
 
 TEST(Disk, MountPoints) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   TestDisk disk(&registry);
   auto mount_points = disk.get_mount_points();
   EXPECT_EQ(mount_points.size(), 7);
@@ -74,7 +76,8 @@ TEST(Disk, dev) {
 }
 
 TEST(Disk, InterestingMountPoints) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   TestDisk disk(&registry);
 
   auto interesting = disk.filter_interesting_mount_points(disk.get_mount_points());
@@ -101,7 +104,8 @@ TEST(Disk, InterestingMountPoints) {
 }
 
 TEST(Disk, UpdateTitusStats) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   TestDisk disk(&registry);
 
   disk.titus_disk_stats();
@@ -113,7 +117,8 @@ TEST(Disk, UpdateTitusStats) {
 }
 
 TEST(Disk, UpdateDiskStats) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   TestDisk disk(&registry);
 
   disk.disk_stats();
@@ -125,7 +130,8 @@ TEST(Disk, UpdateDiskStats) {
 }
 
 TEST(Disk, get_disk_stats) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   TestDisk disk(&registry);
 
   const auto& s = disk.get_disk_stats();
@@ -133,7 +139,8 @@ TEST(Disk, get_disk_stats) {
 }
 
 TEST(Disk, diskio_stats) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   TestDisk disk(&registry);
 
   disk.diskio_stats();

--- a/test/gpu_test.cc
+++ b/test/gpu_test.cc
@@ -6,6 +6,7 @@
 
 using namespace atlasagent;
 
+using atlas::meter::ManualClock;
 using atlas::meter::Measurements;
 
 class TestNvml {
@@ -100,7 +101,8 @@ static void expect_dist_summary(const Measurements& ms, const char* name, double
 }
 
 TEST(Gpu, Metrics) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   registry.SetWall(1000);
   TestNvml nvml;
   auto metrics = GpuMetrics<TestNvml>(&registry, &nvml);

--- a/test/proc_test.cc
+++ b/test/proc_test.cc
@@ -6,12 +6,18 @@
 
 using namespace atlasagent;
 
+using atlas::meter::ManualClock;
 using atlas::meter::Measurements;
-static auto proto_ref = atlas::util::intern_str("proto");
+
+static atlas::util::StrRef proto_ref() {
+  static auto ref = atlas::util::intern_str("proto");
+  return ref;
+}
 
 // TODO: verify values
 TEST(Proc, ParseNetwork) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   registry.SetWall(1000);
   Proc proc{&registry, "./resources/proc"};
 
@@ -29,7 +35,8 @@ TEST(Proc, ParseNetwork) {
 }
 
 TEST(Proc, ParseSnmp) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   registry.SetWall(1000);
   Proc proc{&registry, "./resources/proc"};
 
@@ -42,7 +49,7 @@ TEST(Proc, ParseSnmp) {
   EXPECT_EQ(22 + 5 + 10 + 3, ms.size())
       << "5 metrics for ip, 10 for tcp, 3 for udp + 22 for netstat.tcp";
 
-  measurement_map values = measurements_to_map(ms, proto_ref);
+  measurement_map values = measurements_to_map(ms, proto_ref());
   expect_value(values, "net.tcp.connectionStates|established|v4", 27.0);
   expect_value(values, "net.tcp.connectionStates|established|v6", 0.0);
   expect_value(values, "net.tcp.connectionStates|listen|v4", 10.0);
@@ -52,7 +59,8 @@ TEST(Proc, ParseSnmp) {
 }
 
 TEST(Proc, ParseLoadAvg) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   registry.SetWall(1000);
   Proc proc{&registry, "./resources/proc"};
   proc.loadavg_stats();
@@ -73,14 +81,15 @@ TEST(Proc, ParsePidFromSched) {
 }
 
 TEST(Proc, IsContainer) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   Proc proc{&registry, "./resources/proc"};
   EXPECT_TRUE(proc.is_container());
   proc.set_prefix("./resources/proc-host");
   EXPECT_FALSE(proc.is_container());
 }
 
-bool is_gauge(atlas::meter::IdPtr id) {
+bool is_gauge(const atlas::meter::IdPtr& id) {
   using atlas::util::intern_str;
   const auto& tags = id->GetTags();
   const auto dsType = intern_str("atlas.dstype");
@@ -91,7 +100,8 @@ bool is_gauge(atlas::meter::IdPtr id) {
 }
 
 TEST(Proc, CpuStats) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   Proc proc{&registry, "./resources/proc"};
   proc.cpu_stats();
   registry.SetWall(60000);
@@ -117,12 +127,13 @@ TEST(Proc, CpuStats) {
 }
 
 TEST(Proc, VmStats) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   Proc proc{&registry, "./resources/proc"};
   proc.vmstats();
   registry.SetWall(60000);
   const auto& ms = registry.my_measurements();
-  const auto ms_map = measurements_to_map(ms, proto_ref);
+  const auto ms_map = measurements_to_map(ms, proto_ref());
   EXPECT_EQ(4, ms.size());
   expect_value(ms_map, "vmstat.procs|blocked", 1);
   expect_value(ms_map, "vmstat.procs|running", 2);
@@ -134,7 +145,7 @@ TEST(Proc, VmStats) {
   proc.vmstats();
   registry.SetWall(120000);
   const auto& ms2 = registry.my_measurements();
-  const auto ms2_map = measurements_to_map(ms2, proto_ref);
+  const auto ms2_map = measurements_to_map(ms2, proto_ref());
   EXPECT_EQ(9, ms2.size());
   expect_value(ms2_map, "vmstat.procs|blocked", 2);
   expect_value(ms2_map, "vmstat.procs|running", 3);
@@ -148,11 +159,12 @@ TEST(Proc, VmStats) {
 }
 
 TEST(Proc, MemoryStats) {
-  TestRegistry registry;
+  ManualClock clock;
+  TestRegistry registry(&clock);
   Proc proc{&registry, "./resources/proc"};
   proc.memory_stats();
   const auto& ms = registry.my_measurements();
-  const auto ms_map = measurements_to_map(ms, proto_ref);
+  const auto ms_map = measurements_to_map(ms, proto_ref());
   EXPECT_EQ(9, ms.size());
   expect_value(ms_map, "mem.freeReal", 1024.0 * 9631224);
   expect_value(ms_map, "mem.availReal", 1024.0 * 9557144);

--- a/test/test_registry.h
+++ b/test/test_registry.h
@@ -7,13 +7,15 @@
 
 class TestRegistry : public atlas::meter::AtlasRegistry {
  public:
-  TestRegistry() : atlas::meter::AtlasRegistry(atlas::util::kMainFrequencyMillis, &manual_clock) {
+  TestRegistry(const atlas::meter::ManualClock* manual_clock)
+      : atlas::meter::AtlasRegistry(atlas::util::kMainFrequencyMillis, manual_clock),
+        manual_clock_(manual_clock) {
     // some monitors check for a previous update with if (last_updated > 0) ...
     // so we need to have a value greater than 0 by default
     SetWall(1);
   }
 
-  void SetWall(int64_t millis) { manual_clock.SetWall(millis); }
+  void SetWall(int64_t millis) { manual_clock_->SetWall(millis); }
 
   // non atlas. measurements only
   atlas::meter::Measurements my_measurements() {
@@ -28,5 +30,5 @@ class TestRegistry : public atlas::meter::AtlasRegistry {
   }
 
  private:
-  atlas::meter::ManualClock manual_clock;
+  const atlas::meter::ManualClock* manual_clock_;
 };


### PR DESCRIPTION
Version 0.4.2 uses counters in the AtlasRegistry constructor which means
our clock needs to be functional before, so fix the TestRegistry to deal
with that.