### PR TITLE
Add CPU throttling metrics to cgroup cpu stats

### DIFF
--- a/lib/cgroup.h
+++ b/lib/cgroup.h
@@ -19,6 +19,7 @@ class CGroup {
   void cpu_processing_time() noexcept;
   void cpu_usage_time() noexcept;
   void cpu_shares() noexcept;
+  void cpu_throttle() noexcept;
   void kmem_stats() noexcept;
 };
 

--- a/test/cgroup_test.cc
+++ b/test/cgroup_test.cc
@@ -23,12 +23,14 @@ TEST(CGroup, ParseCpu) {
   registry.SetWall(121000);
   const auto& ms = registry.my_measurements();
   measurement_map map = measurements_to_map(ms, atlas::util::intern_str("proto"));
-  EXPECT_EQ(5, map.size()) << "5 cpu metrics generated";
+  EXPECT_EQ(7, map.size()) << "7 cpu metrics generated";
   EXPECT_DOUBLE_EQ(2, map["cgroup.cpu.usageTime|system"]);
   EXPECT_DOUBLE_EQ(1, map["cgroup.cpu.usageTime|user"]);
   EXPECT_DOUBLE_EQ(10.24, map["cgroup.cpu.processingCapacity"]);
   EXPECT_DOUBLE_EQ(1024, map["cgroup.cpu.shares"]);
   EXPECT_DOUBLE_EQ(0.5, map["cgroup.cpu.processingTime"]);
+  EXPECT_DOUBLE_EQ(2 / 60.0, map["cgroup.cpu.numThrottled"]);
+  EXPECT_DOUBLE_EQ(1 / 60.0, map["cgroup.cpu.throttledTime"]);
 }
 
 TEST(CGroup, ParseMemory) {

--- a/test/resources/cpuacct/cpu.stat
+++ b/test/resources/cpuacct/cpu.stat
@@ -1,0 +1,3 @@
+nr_periods 391745
+nr_throttled 377960
+throttled_time 490671115552727

--- a/test/resources2/cpuacct/cpu.stat
+++ b/test/resources2/cpuacct/cpu.stat
@@ -1,0 +1,3 @@
+nr_periods 391945
+nr_throttled 377962
+throttled_time 490672115552727

--- a/test/resources2/cpuacct/cpuacct.stat
+++ b/test/resources2/cpuacct/cpuacct.stat
@@ -1,2 +1,2 @@
-user 6140
-system 12060
+user 6100
+system 12100


### PR DESCRIPTION
Adds:

* `cgroup.cpu.numThrottled`: number of times tasks in a cgroup have been
throttled (that is, not allowed to run because they have exhausted all of the
available time as specified by their quota).

* `cgroup.cpu.throttledTime`: the total time duration (in seconds) for which
tasks in a cgroup have been throttled.