### PR TITLE
Fix gpu-metrics generation

### DIFF
--- a/atlas-agent.cc
+++ b/atlas-agent.cc
@@ -122,8 +122,7 @@ void collect_system_metrics(atlas::meter::Registry* registry) {
 
   auto gpu = std::unique_ptr<GpuMetrics<Nvml> >(nullptr);
   try {
-    Nvml nvml;
-    gpu.reset(new GpuMetrics<Nvml>(registry, &nvml));
+    gpu.reset(new GpuMetrics<Nvml>(registry, std::make_unique<Nvml>()));
   } catch (...) {
     Logger()->debug("Unable to start collection of GPU metrics");
   }

--- a/lib/nvml.cc
+++ b/lib/nvml.cc
@@ -118,7 +118,7 @@ static NvmlRet resolve_symbols() {
 }
 
 Nvml::Nvml() {
-  NvmlRet load = resolve_symbols();
+  auto load = resolve_symbols();
   if (load != NvmlRet::Success) {
     throw NvmlException(load);
   }
@@ -133,6 +133,7 @@ Nvml::Nvml() {
   if (res != NvmlRet::Success) {
     throw NvmlException(res);
   }
+  Logger()->info("Successfully initialized NVIDIA library");
 }
 
 Nvml::~Nvml() noexcept {
@@ -191,7 +192,7 @@ bool Nvml::get_utilization_rates(NvmlDeviceHandle device, NvmlUtilization* utili
   if ((func = nvml_symtab[NvmlIndex::DeviceGetUtilizationRates].handle) != nullptr) {
     auto nvml_get_rates = reinterpret_cast<NvmlRet (*)(NvmlDeviceHandle, NvmlUtilization*)>(func);
     return to_bool(kFuncName, nvml_get_rates(device, utilization));
-  }
+}
   return to_bool(kFuncName, NvmlRet::ErrorFunctionNotFound);
 }
 

--- a/lib/nvml.h
+++ b/lib/nvml.h
@@ -29,7 +29,7 @@ class Nvml {
  public:
   Nvml();
   ~Nvml() noexcept;
-  Nvml(const Nvml& other) = default;
+  Nvml(const Nvml& other) = delete;
 
   bool get_count(unsigned int* count) noexcept;
   bool get_by_index(unsigned int index, NvmlDeviceHandle* device) noexcept;

--- a/test/gpu_test.cc
+++ b/test/gpu_test.cc
@@ -104,8 +104,7 @@ TEST(Gpu, Metrics) {
   ManualClock clock;
   TestRegistry registry(&clock);
   registry.SetWall(1000);
-  TestNvml nvml;
-  auto metrics = GpuMetrics<TestNvml>(&registry, &nvml);
+  auto metrics = GpuMetrics<TestNvml>(&registry, std::make_unique<TestNvml>());
   metrics.gpu_metrics();
   registry.SetWall(61000);
   const auto& ms = registry.my_measurements();


### PR DESCRIPTION
We were passing a pointer to a temporary variable representing the nvml
library, which went out of scope after the initialization, making
subsequent calls fail