### PR TITLE
Use valid() to check whether a tag key is present

### DIFF
--- a/test/measurement_utils.cc
+++ b/test/measurement_utils.cc
@@ -3,20 +3,20 @@
 #include <gtest/gtest.h>
 
 using atlas::meter::Measurements;
-const auto& id_ref = atlas::util::intern_str("id");
 
 measurement_map measurements_to_map(const Measurements& ms, atlas::util::StrRef secondary) {
+  static auto id_ref = atlas::util::intern_str("id");
   measurement_map res;
   for (const auto& m : ms) {
     std::ostringstream os;
     const auto& tags = m.id->GetTags();
     os << m.id->Name();
     auto it = tags.at(id_ref);
-    if (it.length() > 0) {
+    if (it.valid()) {
       os << "|" << it.get();
     }
     auto proto_it = tags.at(secondary);
-    if (proto_it.length() > 0) {
+    if (proto_it.valid()) {
       os << "|" << proto_it.get();
     }
     res[os.str()] = m.value;


### PR DESCRIPTION
This was using the previously undocumented behavior that we would return
an empty string as a 'no-tag-key' present sentinel. Use the public
`valid()` API instead. This fixes the travis build which was getting a
SEGV due to the null pointer dereference.