### PR TITLE
Gather system metrics at 60s intervals

### DIFF
--- a/lib/proc.h
+++ b/lib/proc.h
@@ -12,6 +12,7 @@ class Proc {
   void snmp_stats() noexcept;
   void loadavg_stats() noexcept;
   void cpu_stats() noexcept;
+  void peak_cpu_stats() noexcept;
   void memory_stats() noexcept;
   void vmstats() noexcept;
   bool is_container() const noexcept;

--- a/test/proc_test.cc
+++ b/test/proc_test.cc
@@ -104,6 +104,7 @@ TEST(Proc, CpuStats) {
   TestRegistry registry(&clock);
   Proc proc{&registry, "./resources/proc"};
   proc.cpu_stats();
+  proc.peak_cpu_stats();
   registry.SetWall(60000);
   const auto& ms = registry.my_measurements();
   EXPECT_EQ(16, ms.size());
@@ -118,6 +119,7 @@ TEST(Proc, CpuStats) {
 
   proc.set_prefix("./resources/proc2");
   proc.cpu_stats();
+  proc.peak_cpu_stats();
   registry.SetWall(120000);
   const auto& ms2 = registry.my_measurements();
   EXPECT_EQ(16, ms2.size());


### PR DESCRIPTION
Due to the way the consolidated registry works for gauges, it's better
to only update system metrics every 60s. The exception is the peak CPU
utilization metrics that were updated every 10s. Switch this collection
to 1s intervals