### PR TITLE
Disable PMU metrics if env variable is set

### DIFF
--- a/lib/perfmetrics.h
+++ b/lib/perfmetrics.h
@@ -210,6 +210,14 @@ class PerfMetrics {
  public:
   PerfMetrics(atlas::meter::Registry* registry, std::string path_prefix)
       : registry_(registry), path_prefix_(std::move(path_prefix)) {
+    static constexpr const char* kDisableEnvVar = "ATLAS_DISABLE_PMU_METRICS";
+    auto disabled_var = std::getenv(kDisableEnvVar);
+    if (disabled_var != nullptr && std::strcmp(disabled_var, "true") == 0) {
+      Logger()->info("PMU metrics have been disabled using the env variable {}", kDisableEnvVar);
+      disabled_ = true;
+      return;
+    }
+
     auto is_perf_supported_name =
         fmt::format("{}/proc/sys/kernel/perf_event_paranoid", path_prefix_);
     if (access(is_perf_supported_name.c_str(), R_OK) != 0) {


### PR DESCRIPTION
Due to an issue with an interaction between Xen and the Intel PMUs, in
some cases there can be very high overhead when switching cgroups
around. This PR provides a mechanism that can be used to disable the
collection of `perf` metrics until such problems are resolved.

To disable, just set ATLAS_DISABLE_PMU_METRICS=true as an environment
variable. You should see the following entry in your logs files
indicating this has taken effect:

```
... [info] PMU metrics have been disabled using the env variable ATLAS_DISABLE_PMU_METRICS
```