### PR TITLE
Do not use fscanf to read a string

### DIFF
--- a/lib/util.cc
+++ b/lib/util.cc
@@ -30,11 +30,14 @@ void parse_kv_from_file(const std::string& prefix, const char* fn,
     return;
   }
 
+  char buffer[1024];
   char key[1024];
   int64_t value;
-  while (std::fscanf(fp, "%s %" PRId64, key, &value) != EOF) {
-    std::string str_key{key};
-    (*stats)[str_key] = value;
+  while (fgets(buffer, sizeof key, fp) != nullptr) {
+    if (sscanf(buffer, "%s %" PRId64, key, &value) == 2) {
+      std::string str_key{key};
+      (*stats)[str_key] = value;
+    }
   }
 }
 


### PR DESCRIPTION
Use fgets to read lines from /proc to add bound checks. This should not
have any difference in practice (since if you can control the contents
of /proc then it's game over) but it will make the code scanning tools
looking for vulnerabilities happier