### PR TITLE
Update to spectator-cpp 0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
   - gcc
 env:
   global:
-    - SPECTATOR_CPP_VERSION=v0.0.5
+    - SPECTATOR_CPP_VERSION=v0.1.0
   matrix:
     - TITUS_AGENT="-DTITUS_AGENT=ON .."
     - TITUS_AGENT=""

--- a/atlas-agent.cc
+++ b/atlas-agent.cc
@@ -22,8 +22,7 @@ using atlasagent::Nvml;
 using atlasagent::PerfMetrics;
 using atlasagent::Proc;
 
-// This should be provided by the runtime
-spectator::Config GetSpectatorConfig();
+std::unique_ptr<spectator::Config> GetSpectatorConfig();
 
 #ifdef TITUS_AGENT
 static void gather_titus_metrics(CGroup* cGroup, Proc* proc, Disk* disk) {
@@ -180,16 +179,16 @@ int main(int argc, const char* argv[]) {
 
   init_signals();
   auto cfg = GetSpectatorConfig();
-  cfg.common_tags["xatlas.process"] = process;
+  cfg->common_tags["xatlas.process"] = process;
 
 #ifdef TITUS_AGENT
   auto titus_host = std::getenv("EC2_INSTANCE_ID");
   if (titus_host != nullptr) {
-    cfg.common_tags["titus.host"] = titus_host;
+    cfg->common_tags["titus.host"] = titus_host;
   }
 #endif
 
-  spectator::Registry registry{cfg, GetLogger("spectator")};
+  spectator::Registry registry{std::move(cfg), GetLogger("spectator")};
   registry.Start();
 #ifdef TITUS_AGENT
   collect_titus_metrics(&registry);

--- a/sample-config.cc
+++ b/sample-config.cc
@@ -1,7 +1,7 @@
 #include <spectator/config.h>
 
-spectator::Config GetSpectatorConfig() {
-  return spectator::Config{};
+std::unique_ptr<spectator::Config> GetSpectatorConfig() {
+  return spectator::GetConfiguration();
 }
 
 

--- a/test/cgroup_test.cc
+++ b/test/cgroup_test.cc
@@ -5,12 +5,12 @@
 #include <gtest/gtest.h>
 
 using namespace atlasagent;
-using spectator::Config;
+using spectator::GetConfiguration;
 using spectator::Registry;
 
 // TODO: verify values
 TEST(CGroup, ParseCpu) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   CGroup cGroup{&registry, "./resources"};
 
   cGroup.cpu_stats();
@@ -36,7 +36,7 @@ TEST(CGroup, ParseCpu) {
 }
 
 TEST(CGroup, ParseMemory) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   CGroup cGroup{&registry, "./resources"};
 
   cGroup.memory_stats();

--- a/test/disk_test.cc
+++ b/test/disk_test.cc
@@ -12,7 +12,7 @@ std::unordered_set<std::string> get_nodev_filesystems(const std::string& prefix)
 }  // namespace atlasagent
 
 using namespace atlasagent;
-using spectator::Config;
+using spectator::GetConfiguration;
 using spectator::Registry;
 using spectator::Tags;
 
@@ -46,7 +46,7 @@ TEST(Disk, NodevFS) {
 }
 
 TEST(Disk, MountPoints) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   TestDisk disk(&registry);
   auto mount_points = disk.get_mount_points();
   EXPECT_EQ(mount_points.size(), 7);
@@ -71,7 +71,7 @@ TEST(Disk, dev) {
 }
 
 TEST(Disk, InterestingMountPoints) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   TestDisk disk(&registry);
 
   auto interesting = disk.filter_interesting_mount_points(disk.get_mount_points());
@@ -91,7 +91,7 @@ TEST(Disk, InterestingMountPoints) {
 }
 
 TEST(Disk, UpdateTitusStats) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   TestDisk disk(&registry);
 
   disk.titus_disk_stats();
@@ -103,7 +103,7 @@ TEST(Disk, UpdateTitusStats) {
 }
 
 TEST(Disk, UpdateDiskStats) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   TestDisk disk(&registry);
 
   disk.disk_stats();
@@ -133,7 +133,7 @@ TEST(Disk, UpdateDiskStats) {
 }
 
 TEST(Disk, get_disk_stats) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   TestDisk disk(&registry);
 
   const auto& s = disk.get_disk_stats();
@@ -141,7 +141,7 @@ TEST(Disk, get_disk_stats) {
 }
 
 TEST(Disk, diskio_stats) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   TestDisk disk(&registry);
 
   disk.diskio_stats();

--- a/test/gpu_test.cc
+++ b/test/gpu_test.cc
@@ -6,7 +6,7 @@
 
 using namespace atlasagent;
 
-using spectator::Config;
+using spectator::GetConfiguration;
 using spectator::Registry;
 using Measurements = std::vector<spectator::Measurement>;
 
@@ -100,7 +100,7 @@ static void expect_dist_summary(const Measurements& ms, const char* name, double
 }
 
 TEST(Gpu, Metrics) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   auto metrics = GpuMetrics<TestNvml>(&registry, std::make_unique<TestNvml>());
   metrics.gpu_metrics();
   const auto& ms = registry.Measurements();

--- a/test/perfmetrics_test.cc
+++ b/test/perfmetrics_test.cc
@@ -2,11 +2,11 @@
 #include <gtest/gtest.h>
 
 using atlasagent::PerfMetrics;
-using spectator::Config;
+using spectator::GetConfiguration;
 using spectator::Registry;
 
 TEST(PerfMetrics, OnlineCpus) {
-  Registry registry{Config{}, atlasagent::Logger()};
+  Registry registry{GetConfiguration(), atlasagent::Logger()};
   PerfMetrics p{&registry, "./resources"};
 
   // 0-3,5-7,10-15,23

--- a/test/proc_test.cc
+++ b/test/proc_test.cc
@@ -6,12 +6,12 @@
 
 using namespace atlasagent;
 
-using spectator::Config;
+using spectator::GetConfiguration;
 using spectator::Registry;
 using Measurements = std::vector<spectator::Measurement>;
 
 TEST(Proc, ParseNetwork) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
 
   proc.network_stats();
@@ -45,7 +45,7 @@ TEST(Proc, ParseNetwork) {
 }
 
 TEST(Proc, ParseSnmp) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
 
   proc.snmp_stats();
@@ -105,7 +105,7 @@ TEST(Proc, ParseSnmp) {
 }
 
 TEST(Proc, ParseLoadAvg) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
   proc.loadavg_stats();
   const auto& ms = registry.Measurements();
@@ -125,7 +125,7 @@ TEST(Proc, ParsePidFromSched) {
 }
 
 TEST(Proc, IsContainer) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
   EXPECT_TRUE(proc.is_container());
   proc.set_prefix("./resources/proc-host");
@@ -139,7 +139,7 @@ bool is_gauge(const spectator::IdPtr& id) {
 }
 
 TEST(Proc, CpuStats) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
   proc.cpu_stats();
   proc.peak_cpu_stats();
@@ -154,7 +154,7 @@ TEST(Proc, CpuStats) {
 }
 
 TEST(Proc, VmStats) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
   proc.vmstats();
   auto ms = registry.Measurements();
@@ -181,7 +181,7 @@ TEST(Proc, VmStats) {
 }
 
 TEST(Proc, MemoryStats) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
   proc.memory_stats();
   auto ms = registry.Measurements();
@@ -199,7 +199,7 @@ TEST(Proc, MemoryStats) {
 }
 
 TEST(Proc, ParseNetstat) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
   proc.netstat_stats();
   EXPECT_TRUE(registry.Measurements().empty());
@@ -216,7 +216,7 @@ TEST(Proc, ParseNetstat) {
 }
 
 TEST(Proc, ArpStats) {
-  Registry registry(Config{}, Logger());
+  Registry registry(GetConfiguration(), Logger());
   Proc proc{&registry, "./resources/proc"};
   proc.arp_stats();
   const auto ms = registry.Measurements();


### PR DESCRIPTION
Which makes the Config a class. This allows Config implementations to
override an `is_enabled` method with custom logic to avoid publishing
metrics under certain conditions