### PR TITLE
Sample system metrics more frequently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
     - TITUS_AGENT=""
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
       - zlib1g-dev 
       - uuid-dev 

--- a/lib/logger.cc
+++ b/lib/logger.cc
@@ -26,9 +26,7 @@ LogManager::LogManager() noexcept {
 std::shared_ptr<spdlog::logger> LogManager::Logger() noexcept { return logger_; }
 
 std::shared_ptr<spdlog::logger> LogManager::GetLogger(const std::string& name) noexcept {
-  auto logger = spdlog::create_async_nb<spdlog::sinks::ansicolor_stdout_sink_mt>(name);
-  logger->set_level(spdlog::level::info);
-  return logger;
+  return spdlog::create_async_nb<spdlog::sinks::ansicolor_stdout_sink_mt>(name);
 }
 
 }  // namespace atlasagent


### PR DESCRIPTION
This changes the sampling frequency of the slow system metrics from 1
minute to every 30 seconds. Also adds a hook to get verbose logging by
setting the env variable VERBOSE_AGENT.