### PR TITLE
Fix system metrics loop

### DIFF
--- a/atlas-agent.cc
+++ b/atlas-agent.cc
@@ -151,7 +151,7 @@ void collect_system_metrics(spectator::Registry* registry) {
   gather_slow_system_metrics(&proc, &disk);
   do {
     gather_peak_system_metrics(&proc);
-    if (now >= next_slow_run) {
+    if (system_clock::now() >= next_slow_run) {
       gather_slow_system_metrics(&proc, &disk);
       perf_metrics.collect();
       next_slow_run += seconds(30);


### PR DESCRIPTION
It was not updating the value of now so the gather_system_metrics
call was only executed at startup