### PR TITLE
Use ntp as the source of truth for time data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ set(CMAKE_BUILD_TYPE, RelWithDebInfo)
 include_directories(3rd-party /usr/local/include contain ${PROJECT_SOURCE_DIR}/nc/root/include)
 link_directories(/usr/local/lib ${PROJECT_SOURCE_DIR}/nc/root/lib)
 
-file(GLOB LIB_SOURCE_FILES lib/*.cc lib/*.h)
+file(GLOB LIB_SOURCE_FILES lib/[a-zA-Z]*.cc lib/[a-zA-Z]*.h)
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   link_directories(/usr/lib/x86_64-linux-gnu)
   add_library(contain OBJECT contain/contain.c)

--- a/test/ntp_test.cc
+++ b/test/ntp_test.cc
@@ -1,10 +1,10 @@
-#include "../lib/chrony.h"
+#include "../lib/ntp.h"
 #include "../lib/logger.h"
 #include "measurement_utils.h"
 #include <gtest/gtest.h>
 
-using atlasagent::Chrony;
 using atlasagent::Logger;
+using atlasagent::Ntp;
 
 struct TestClock : std::chrono::system_clock {
   using base_type = std::chrono::system_clock;
@@ -14,26 +14,29 @@ struct TestClock : std::chrono::system_clock {
   }
 };
 
-class CT : public Chrony<TestClock> {
+class CT : public Ntp<TestClock> {
  public:
-  CT(spectator::Registry* registry) : Chrony{registry} {}
+  CT(spectator::Registry* registry) : Ntp{registry} {}
   void stats(const std::string& tracking, const std::vector<std::string>& sources) noexcept {
-    Chrony::tracking_stats(tracking, sources);
+    Ntp::chrony_stats(tracking, sources);
+  }
+  void ntp(int err, timex* time) {
+    Ntp::ntp_stats(err, time);
   }
 
   TestClock::time_point lastSample() const { return lastSampleTime_; }
 };
 
-double get_default_sample_age(const CT& chrony) {
+double get_default_sample_age(const CT& ntp) {
   auto nanos =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(TestClock::now() - chrony.lastSample())
+      std::chrono::duration_cast<std::chrono::nanoseconds>(TestClock::now() - ntp.lastSample())
           .count();
   return nanos / 1e9;
 }
 
-TEST(Chrony, Stats) {
+TEST(Ntp, Stats) {
   spectator::Registry registry{spectator::GetConfiguration(), Logger()};
-  CT chrony{&registry};
+  CT ntp{&registry};
 
   std::string tracking =
       "A9FEA97B,169.254.169.123,4,1553630752.756016394,0.000042,-0.000048721,"
@@ -43,27 +46,26 @@ TEST(Chrony, Stats) {
       "^,*,169.254.169.123,3,8,377,74,-0.000027989,-0.000076710,0.000319246\n",
       "^,-,10.229.0.50,2,10,340,7219,0.002353442,0.001586549,0.049785987\n",
       "^,-,172.16.1.2,2,10,337,1028,0.000021583,-0.000021316,0.049278442\n"};
-  chrony.stats(tracking, sources);
+  ntp.stats(tracking, sources);
 
   auto ms = registry.Measurements();
   auto map = measurements_to_map(ms, "");
-  std::unordered_map<std::string, double> expected = {{"sys.time.offset", 0.000042},
-                                                      {"sys.time.lastSampleAge", 74}};
+  std::unordered_map<std::string, double> expected = {{"sys.time.lastSampleAge", 74}};
   EXPECT_EQ(map, expected);
 }
 
-TEST(Chrony, StatsEmpty) {
+TEST(Ntp, StatsEmpty) {
   spectator::Registry registry{spectator::GetConfiguration(), Logger()};
-  CT chrony{&registry};
-  chrony.stats("", {});
+  CT ntp{&registry};
+  ntp.stats("", {});
 
   auto ms = registry.Measurements();
-  EXPECT_EQ(ms.size(), 1); // we always report 
+  EXPECT_EQ(ms.size(), 1);  // we always report
 }
 
-TEST(Chrony, StatsInvalid) {
+TEST(Ntp, StatsInvalid) {
   spectator::Registry registry{spectator::GetConfiguration(), Logger()};
-  CT chrony{&registry};
+  CT ntp{&registry};
 
   std::string tracking =
       "A9FEA97B,1.2.3.4,4,1.1,foo,-0.021,1,-2,-0.022,0.079,0.0005,0.0001,775.8,Normal\n";
@@ -72,21 +74,21 @@ TEST(Chrony, StatsInvalid) {
       "^,*,1.2.3.4,3,8,377,abc,-0.000027989,-0.000076710,0.000319246\n",
       "^,-,10.229.0.50,2,10,340,7219,0.002353442,0.001586549,0.049785987\n",
       "^,-,172.16.1.2,2,10,337,1028,0.000021583,-0.000021316,0.049278442\n"};
-  chrony.stats(tracking, sources);
+  ntp.stats(tracking, sources);
 
   auto ms = registry.Measurements();
   auto map = measurements_to_map(ms, "");
 
   std::unordered_map<std::string, double> expected = {
-      {"sys.time.lastSampleAge", get_default_sample_age(chrony)}};
+      {"sys.time.lastSampleAge", get_default_sample_age(ntp)}};
   EXPECT_EQ(expected, map);
 }
 
 // ensure we deal properly when the server in tracking gets lost
-// (maybe a race between the commands chronyc tracking; chronyc sources)
-TEST(Chrony, NoSources) {
+// (maybe a race between the commands ntpc tracking; ntpc sources)
+TEST(Ntp, NoSources) {
   spectator::Registry registry{spectator::GetConfiguration(), Logger()};
-  CT chrony{&registry};
+  CT ntp{&registry};
 
   std::string tracking =
       "A9FEA97B,1.2.3.4,4,1.1,10,-0.021,1,-2,-0.022,0.079,0.0005,0.0001,775.8,Normal\n";
@@ -95,11 +97,43 @@ TEST(Chrony, NoSources) {
       "^,*,1.2.3.5,3,8,377,abc,-0.000027989,-0.000076710,0.000319246\n",
       "^,-,10.229.0.50,2,10,340,7219,0.002353442,0.001586549,0.049785987\n",
       "^,-,172.16.1.2,2,10,337,1028,0.000021583,-0.000021316,0.049278442\n"};
-  chrony.stats(tracking, sources);
+  ntp.stats(tracking, sources);
 
   auto ms = registry.Measurements();
   auto map = measurements_to_map(ms, "");
   std::unordered_map<std::string, double> expected = {
-      {"sys.time.offset", 10}, {"sys.time.lastSampleAge", get_default_sample_age(chrony)}};
+      {"sys.time.lastSampleAge", get_default_sample_age(ntp)}};
+  EXPECT_EQ(map, expected);
+}
+
+TEST(Ntp, adjtime) {
+  spectator::Registry registry{spectator::GetConfiguration(), Logger()};
+  CT ntp{&registry};
+
+  struct timex t{};
+  t.esterror = 100000;
+  ntp.ntp(TIME_OK, &t);
+
+  auto ms = registry.Measurements();
+  auto map = measurements_to_map(ms, "");
+  std::unordered_map<std::string, double> expected = {
+      {"sys.time.unsynchronized", 0},
+      {"sys.time.estimatedError", 0.1}};
+  EXPECT_EQ(map, expected);
+}
+
+TEST(Ntp, adjtime_err) {
+  spectator::Registry registry{spectator::GetConfiguration(), Logger()};
+  CT ntp{&registry};
+
+  struct timex t{};
+  t.esterror = 200000;
+  ntp.ntp(TIME_ERROR, &t);
+
+  auto ms = registry.Measurements();
+  auto map = measurements_to_map(ms, "");
+  std::unordered_map<std::string, double> expected = {
+      {"sys.time.unsynchronized", 1},
+      {"sys.time.estimatedError", 0.2}};
   EXPECT_EQ(map, expected);
 }


### PR DESCRIPTION
This switches the source of truth from `chronyc tracking` to
`ntp_adjtime` for the `sys.time.offset` metric which gets renamed as
`sys.time.estimatedError`. In addition we add a metric to track when ntp
is not synchronized.