### PR TITLE
Collect system metrics every 60s

### DIFF
--- a/atlas-agent.cc
+++ b/atlas-agent.cc
@@ -158,7 +158,7 @@ void collect_system_metrics(spectator::Registry* registry) {
     if (system_clock::now() >= next_slow_run) {
       gather_slow_system_metrics(&proc, &disk, &ntp);
       perf_metrics.collect();
-      next_slow_run += seconds(30);
+      next_slow_run += seconds(60);
       if (gpu) {
         gpu->gpu_metrics();
       }


### PR DESCRIPTION
We were unintentedly gathering the metrics every 30s instead of the
intended 60s.