### PR TITLE
Make cgroup.cpu.processingCapacity a counter

### DIFF
--- a/lib/cgroup.h
+++ b/lib/cgroup.h
@@ -6,8 +6,10 @@ namespace atlasagent {
 
 class CGroup {
  public:
-  explicit CGroup(spectator::Registry* registry,
-                  std::string path_prefix = "/sys/fs/cgroup") noexcept;
+  using time_point = spectator::Registry::clock::time_point;
+
+  explicit CGroup(spectator::Registry* registry, std::string path_prefix = "/sys/fs/cgroup",
+                  std::chrono::seconds update_interval = std::chrono::seconds{60}) noexcept;
   void cpu_stats() noexcept;
   void memory_stats() noexcept;
   void set_prefix(std::string new_prefix) noexcept { path_prefix_ = std::move(new_prefix); }
@@ -15,12 +17,18 @@ class CGroup {
  private:
   spectator::Registry* registry_;
   std::string path_prefix_;
+  std::chrono::seconds update_interval_;
+  spectator::Registry::clock::time_point last_updated_{};
 
   void cpu_processing_time() noexcept;
   void cpu_usage_time() noexcept;
-  void cpu_shares() noexcept;
+  void cpu_shares(time_point now) noexcept;
   void cpu_throttle() noexcept;
   void kmem_stats() noexcept;
+
+ protected:
+  // for testing
+  void do_cpu_stats(time_point now) noexcept;
 };
 
 }  // namespace atlasagent


### PR DESCRIPTION
This is mostly to behave better when consolidation is required. A very
common graph is to plot CPU utilization by diving processingTime by
processingCapacity. Previously processingCapacity was reported as a
gauge and that caused issues due to the difference in behavior in the
consolidation of counters and gauges.