### PR TITLE
Handle chronyc not installed

### DIFF
--- a/lib/ntp.h
+++ b/lib/ntp.h
@@ -15,9 +15,11 @@ class Ntp {
         unsynchronized_{registry->GetGauge("sys.time.unsynchronized")} {}
 
   void update_stats() noexcept {
-    auto tracking_csv = read_output_string("chronyc -c tracking");
-    auto sources_csv = read_output_lines("chronyc -c sources");
-    chrony_stats(tracking_csv, sources_csv);
+    if (can_execute("chronyc")) {
+      auto tracking_csv = read_output_string("chronyc -c tracking");
+      auto sources_csv = read_output_lines("chronyc -c sources");
+      chrony_stats(tracking_csv, sources_csv);
+    }
 
     struct timex time {};
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -26,4 +26,7 @@ std::string read_output_string(const char* cmd);
 // Execute cmd using the shell and return its output as a vector of lines
 std::vector<std::string> read_output_lines(const char* cmd);
 
+// determine whether the program passed is available
+bool can_execute(const std::string& program);
+
 }  // namespace atlasagent

--- a/test/utils_test.cc
+++ b/test/utils_test.cc
@@ -48,3 +48,13 @@ TEST(Utils, ReadOutputLinesErr) {
   auto v = atlasagent::read_output_string("/bin/does-not-exist");
   EXPECT_TRUE(v.empty());
 }
+
+TEST(Utils, CanExecute) {
+  EXPECT_TRUE(atlasagent::can_execute("echo"));
+  EXPECT_FALSE(atlasagent::can_execute("program-does-not-exist"));
+}
+
+TEST(Utils, CanExecuteFullPath) {
+  EXPECT_TRUE(atlasagent::can_execute("/bin/sh"));
+  EXPECT_FALSE(atlasagent::can_execute("/bin/pr-does-not-exist"));
+}


### PR DESCRIPTION
This is not present by default on CentOS/RHEL. Avoid polluting the logs
with the failure to execute messages