### PR TITLE
Track AWS credentials expiration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
   - gcc
 env:
   global:
-    - SPECTATOR_CPP_VERSION=v0.2.1
+    - SPECTATOR_CPP_VERSION=v0.7.0
   matrix:
     - TITUS_AGENT="-DTITUS_AGENT=ON .."
     - TITUS_AGENT=""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option (TITUS_AGENT
 configure_file("${PROJECT_SOURCE_DIR}/config.h.in" "${PROJECT_SOURCE_DIR}/config.h")
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_BUILD_TYPE, RelWithDebInfo)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 include_directories(3rd-party /usr/local/include contain ${PROJECT_SOURCE_DIR}/nc/root/include)
 link_directories(/usr/local/lib ${PROJECT_SOURCE_DIR}/nc/root/lib)

--- a/lib/aws.cc
+++ b/lib/aws.cc
@@ -1,0 +1,99 @@
+#include "aws.h"
+
+namespace atlasagent {
+
+static constexpr const char* const kMetadataUrl =
+    "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+
+Aws::Aws(spectator::Registry* registry) noexcept
+    : registry_{registry},
+      http_client_{registry,
+                   spectator::HttpClientConfig{std::chrono::seconds{1}, std::chrono::seconds{1},
+                                               false, true, true}} {}
+
+void Aws::update_stats() noexcept {
+  if (creds_url_.empty()) {
+    auto resp = http_client_.Get(kMetadataUrl);
+    if (resp.status == 200) {
+      creds_url_ = fmt::format("{}{}", kMetadataUrl, resp.raw_body);
+      Logger()->info("Using {} as the credentials URL", creds_url_);
+    } else {
+      return;
+    }
+  }
+
+  auto res = http_client_.Get(creds_url_);
+  if (res.status != 200) {
+    registry_->GetCounter("aws.credentialsRefreshErrors")->Increment();
+    return;
+  }
+
+  update_stats_from(std::chrono::system_clock::now(), res.raw_body);
+}
+
+static std::chrono::system_clock::time_point getDateFrom(const rapidjson::Document& doc,
+                                                         const char* dateStr) {
+  time_t t;
+  if (doc.HasMember(dateStr)) {
+    auto p = doc[dateStr].GetString();
+    tm datetime{};
+    strptime(p, "%Y-%m-%dT%TZ", &datetime);
+    t = timegm(&datetime);
+  } else {
+    t = 0;
+  }
+  return std::chrono::system_clock::from_time_t(t);
+}
+
+void Aws::update_stats_from(std::chrono::system_clock::time_point now,
+                            const std::string& json) noexcept {
+  rapidjson::Document creds;
+  creds.Parse(json.c_str(), json.length());
+  if (creds.HasParseError()) {
+    Logger()->warn("Unable to parse {} as JSON", json);
+    registry_->GetCounter("aws.credentialsRefreshErrors")->Increment();
+    return;
+  }
+
+  if (!creds.IsObject()) {
+    Logger()->warn("Got {} which is not a JSON object", json);
+    registry_->GetCounter("aws.credentialsRefreshErrors")->Increment();
+    return;
+  }
+
+  auto lastUpdated = getDateFrom(creds, "LastUpdated");
+  if (lastUpdated.time_since_epoch().count() > 0) {
+    auto updatedAge = now - lastUpdated;
+    auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(updatedAge).count();
+    registry_->GetGauge("aws.credentialsAge")->Set(millis / 1e3);
+  }
+
+  auto expiration = getDateFrom(creds, "Expiration");
+
+  if (expiration.time_since_epoch().count() > 0) {
+    auto ttl = expiration - now;
+    auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(ttl).count();
+    registry_->GetGauge("aws.credentialsTtl")->Set(millis / 1e3);
+
+    std::string bucket;
+    // update some buckets
+    if (ttl.count() < 0) {
+      bucket = "expired";
+    } else if (ttl <= std::chrono::minutes{5}) {
+      bucket = "05min";
+    } else if (ttl <= std::chrono::minutes{30}) {
+      bucket = "30min";
+    } else if (ttl <= std::chrono::minutes{60}) {
+      bucket = "60min";
+    } else {
+      bucket = "hours";
+    }
+
+    registry_
+        ->GetCounter(
+            registry_->CreateId("aws.credentialsTtlBucket", spectator::Tags{{"bucket", bucket}}))
+        ->Increment();
+  }
+}
+
+}  // namespace atlasagent

--- a/lib/aws.h
+++ b/lib/aws.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <spectator/http_client.h>
+#include <spectator/registry.h>
+#include "logger.h"
+
+namespace atlasagent {
+class Aws {
+ public:
+  explicit Aws(spectator::Registry* registry) noexcept;
+
+  void update_stats() noexcept;
+
+ private:
+  spectator::Registry* registry_;
+
+  std::string metadata_url_;
+  std::string creds_url_;
+
+  spectator::HttpClient http_client_;
+
+ protected:
+  void update_stats_from(std::chrono::system_clock::time_point now,
+                         const std::string& json) noexcept;
+};
+
+}  // namespace atlasagent

--- a/lib/logger.h
+++ b/lib/logger.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <spdlog/spdlog.h>
-#include <vector>
 
 namespace atlasagent {
 

--- a/run-build.sh
+++ b/run-build.sh
@@ -17,7 +17,7 @@ if [ "$CC" = gcc ] ; then
   export CXX=g++-5
 fi
 
-# Fetch and build libatlasclient
+# Fetch and build spectator-cpp
 rm -rf nc
 mkdir nc
 cd nc

--- a/test/aws_test.cc
+++ b/test/aws_test.cc
@@ -1,0 +1,83 @@
+#include "../lib/aws.h"
+#include "../lib/logger.h"
+#include "measurement_utils.h"
+#include <fmt/ostream.h>
+
+#include <gtest/gtest.h>
+
+using namespace atlasagent;
+using spectator::GetConfiguration;
+using spectator::Registry;
+using std::chrono::seconds;
+using std::chrono::system_clock;
+
+static std::string to_str(system_clock::time_point t) {
+  auto tt = system_clock::to_time_t(t);
+
+  auto ptm = gmtime(&tt);
+  // "2019-09-10T22:22:58Z"
+  return fmt::format("{}-{:02}-{:02}T{:02}:{:02}:{:02}Z", ptm->tm_year + 1900, ptm->tm_mon + 1,
+                     ptm->tm_mday, ptm->tm_hour, ptm->tm_min, ptm->tm_sec);
+}
+
+class AwsTest : public Aws {
+ public:
+  explicit AwsTest(Registry* registry) : Aws{registry} {}
+
+  void update_stats(system_clock::time_point now, system_clock::time_point lastUpdated,
+                    system_clock::time_point expires) {
+    auto lastUpdatedStr = to_str(lastUpdated);
+    auto expiresStr = to_str(expires);
+    auto json = fmt::format(R"json(
+{{
+  "Code" : "Success",
+  "LastUpdated" : "{}",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "KeyId",
+  "SecretAccessKey" : "SomeSecret",
+  "Token" : "SomeToken",
+  "Expiration" : "{}"
+}}
+  )json",
+                            lastUpdatedStr, expiresStr);
+
+    Aws::update_stats_from(now, json);
+  }
+};
+
+// now() truncated to seconds
+static system_clock::time_point currentTime() {
+  auto seconds_since_epoch =
+      std::chrono::duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
+  return std::chrono::system_clock::from_time_t(seconds_since_epoch);
+}
+
+TEST(Aws, UpdateStats) {
+  Registry registry(GetConfiguration(), Logger());
+
+  auto now = currentTime();
+  auto lastUpdated = now - seconds{600};
+  auto expires = now + seconds{900};
+
+  AwsTest aws{&registry};
+  aws.update_stats(now, lastUpdated, expires);
+
+  auto res = measurements_to_map(registry.Measurements(), "bucket");
+  EXPECT_DOUBLE_EQ(res["aws.credentialsAge|gauge"], 600.0);
+  EXPECT_DOUBLE_EQ(res["aws.credentialsTtl|gauge"], 900.0);
+  EXPECT_DOUBLE_EQ(res["aws.credentialsTtlBucket|count|30min"], 1.0);
+
+  expires = now - seconds{1};
+  aws.update_stats(now, lastUpdated, expires);
+  res = measurements_to_map(registry.Measurements(), "bucket");
+  EXPECT_DOUBLE_EQ(res["aws.credentialsAge|gauge"], 600.0);
+  EXPECT_DOUBLE_EQ(res["aws.credentialsTtl|gauge"], -1.0);
+  EXPECT_DOUBLE_EQ(res["aws.credentialsTtlBucket|count|expired"], 1.0);
+
+  expires = now + std::chrono::hours{12};
+  aws.update_stats(now, lastUpdated, expires);
+  res = measurements_to_map(registry.Measurements(), "bucket");
+  EXPECT_DOUBLE_EQ(res["aws.credentialsAge|gauge"], 600.0);
+  EXPECT_DOUBLE_EQ(res["aws.credentialsTtl|gauge"], 12 * 3600.0);
+  EXPECT_DOUBLE_EQ(res["aws.credentialsTtlBucket|count|hours"], 1.0);
+}


### PR DESCRIPTION
Add the following metrics:

* `aws.credentialsAge`: Age in seconds since the credentials
were last updated.

* `aws.credentialsTtl`: Seconds remaining for the credentials to remain
valid

* `aws.credentialsTtlBucket`: A counter that buckets the ttl into:

  * `bucket=expired` - credentials expired
  * `bucket=05min` - credentials have 5 minutes or less of validity left
  * `bucket=30min` - credentials have between 5 and 30 minutes of
  validity left
  * `bucket=60min` - credentials have between 30 and 60 minutes of
  validity left.
  * `bucket=hours` - credentials have more than 60 minutes left.

* `aws.credentialsRefreshErrors` : If there are errors hitting the AWS
metadata endpoint (or it responds with unexpected data)