### PR TITLE
More verbose messages when loading the NVidia lib

### DIFF
--- a/lib/nvml.cc
+++ b/lib/nvml.cc
@@ -105,11 +105,17 @@ static NvmlRet resolve_symbols() {
     return NvmlRet::Success;
   }
 
-  if ((nvml_dso = dlopen(kNvidiaLib, RTLD_NOW)) == nullptr) {
+  const char* library = getenv("NVIDIA_LIBRARY");
+  if (library == nullptr) {
+    library = kNvidiaLib;
+  }
+
+  Logger()->debug("Attemping to load {}", library);
+  if ((nvml_dso = dlopen(library, RTLD_NOW)) == nullptr) {
     return NvmlRet::ErrorLibraryNotFound;
   }
 
-  Logger()->info("Successfully opened NVIDIA NVML library");
+  Logger()->info("Successfully opened NVIDIA NVML library: {}", library);
 
   for (auto& sh : nvml_symtab) {
     sh.handle = dlsym(nvml_dso, sh.symbol);


### PR DESCRIPTION
Previously we would not display the cause of the failure to initialize
the gpu metrics, or the name of the shared library we were attempting to
load.

Now we get an error message like:

```
[debug] Attemping to load libnvidia-ml.so
[debug] Unable to start collection of GPU metrics: NVML Shared Library couldn't be found or loaded
```

The library name can be overriden by setting the environment variable `NVIDIA_LIBRARY`

For example:

```
 sudo env VERBOSE_AGENT=1 NVIDIA_LIBRARY=/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.430.50 ./atlas-titus-agent
 ...
 [debug] Attemping to load /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.430.50
 ...
```