### PR TITLE
Fix race condition when counting threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
   - gcc
 env:
   global:
-    - SPECTATOR_CPP_VERSION=v0.7.0
+    - SPECTATOR_CPP_VERSION=v0.7.3
   matrix:
     - TITUS_AGENT="-DTITUS_AGENT=ON .."
     - TITUS_AGENT=""

--- a/lib/proc.cc
+++ b/lib/proc.cc
@@ -723,8 +723,11 @@ static bool all_digits(const char* str) {
 
 int32_t count_tasks(const std::string& dirname) {
   DirHandle dh{dirname.c_str()};
-  auto count = 0;
+  if (!dh) {
+    return 0;
+  }
 
+  auto count = 0;
   for (;;) {
     auto entry = readdir(dh);
     if (entry == nullptr) break;
@@ -741,6 +744,10 @@ void Proc::process_stats() noexcept {
   static auto cur_threads = registry_->GetGauge("sys.currentThreads");
 
   DirHandle dir_handle{path_prefix_.c_str()};
+  if (!dir_handle) {
+    return;
+  }
+
   auto pids = 0, tasks = 0;
   for (;;) {
     auto entry = readdir(dir_handle);


### PR DESCRIPTION
While attempting to count the number of threads(tasks) the process might
have exited, making the `diropen` call to `/proc/$pid/task` fail.
Without the check we would get segment violation.