### PR TITLE
Add command line options to specify extra tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ root/
 .idea
 *.swp
 config.h
-nc/
+nc
 cmake-build

--- a/contain/contain.c
+++ b/contain/contain.c
@@ -220,7 +220,7 @@ static int read_buf(char *pid1dir, char **env, int *length, struct stat *st) {
 static char *LD_LIBRARY_PATH = "/proc/self/lib/x86_64-linux-gnu:/proc/self/usr/local/lib";
 static char *LD_BIND_NOW1 = "LD_BIND_NOW=1";
 
-bool maybe_reexec(const char* argv[]) {
+bool maybe_reexec(char* const* argv) {
 	char user_gid_env[128], user_uid_env[128];
 	char *pid1dir, *env = NULL;
 	int err, offset = 0;

--- a/contain/contain.h
+++ b/contain/contain.h
@@ -11,10 +11,10 @@ struct container_handle {
 #include <stdbool.h>
 
 #ifdef __linux__
-bool maybe_reexec(const char* argv[]);
+bool maybe_reexec(char* const* argv);
 int maybe_contain(struct container_handle *);
 #else
-inline bool maybe_reexec(const char* /*argv*/[]) {
+inline bool maybe_reexec(char* const* /*argv*/) {
 	return false;
 }
 

--- a/lib/proc.h
+++ b/lib/proc.h
@@ -5,7 +5,8 @@
 namespace atlasagent {
 class Proc {
  public:
-  explicit Proc(spectator::Registry* registry, std::string path_prefix = "/proc") noexcept;
+  explicit Proc(spectator::Registry* registry, spectator::Tags net_tags,
+                std::string path_prefix = "/proc") noexcept;
   void network_stats() noexcept;
   void arp_stats() noexcept;
   void snmp_stats() noexcept;
@@ -22,6 +23,7 @@ class Proc {
 
  private:
   spectator::Registry* registry_;
+  const spectator::Tags net_tags_;
   std::string path_prefix_;
 
   void handle_line(FILE* fp) noexcept;

--- a/lib/util.cc
+++ b/lib/util.cc
@@ -142,7 +142,9 @@ spectator::Tags parse_tags(const char* s) {
     if (pos != std::string::npos) {
       auto key = f.substr(0, pos);
       auto value = f.substr(pos + 1, f.length());
-      tags.add(key, value);
+      if (!key.empty() && !value.empty()) {
+        tags.add(key, value);
+      }
     }
   }
   return tags;

--- a/lib/util.cc
+++ b/lib/util.cc
@@ -132,4 +132,20 @@ bool can_execute(const std::string& program) {
   return false;
 }
 
+spectator::Tags parse_tags(const char* s) {
+  spectator::Tags tags{};
+  std::vector<std::string> fields{};
+  split(
+      s, [](int ch) { return ch == ',' || ch == ' '; }, &fields);
+  for (const auto& f : fields) {
+    auto pos = f.find('=');
+    if (pos != std::string::npos) {
+      auto key = f.substr(0, pos);
+      auto value = f.substr(pos + 1, f.length());
+      tags.add(key, value);
+    }
+  }
+  return tags;
+}
+
 }  // namespace atlasagent

--- a/lib/util.h
+++ b/lib/util.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 #include "files.h"
+#include <spectator/id.h>
 
 namespace atlasagent {
 
@@ -28,5 +29,8 @@ std::vector<std::string> read_output_lines(const char* cmd);
 
 // determine whether the program passed is available
 bool can_execute(const std::string& program);
+
+// parse a string of the form key=val,key2=val2 into spectator Tags
+spectator::Tags parse_tags(const char* s);
 
 }  // namespace atlasagent

--- a/scripts/start-atlas-agent
+++ b/scripts/start-atlas-agent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SERVICENAME=atlas-system-agent
-DFLT_FILE=/etc/default/atlas-system-agent
+DFLT_FILE=/etc/default/$SERVICENAME
 
 if [[ -n "$TRACE" ]]; then
   export PS4='${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'

--- a/test/measurement_utils.cc
+++ b/test/measurement_utils.cc
@@ -20,6 +20,10 @@ measurement_map measurements_to_map(const std::vector<Measurement>& ms,
     if (!proto_it.empty()) {
       os << "|" << proto_it;
     }
+    auto extra = tags.at("nf.test");
+    if (!extra.empty()) {
+      os << "|" << extra;
+    }
     res[os.str()] = m.value;
   }
   return res;

--- a/test/proc_test.cc
+++ b/test/proc_test.cc
@@ -12,7 +12,8 @@ using Measurements = std::vector<spectator::Measurement>;
 
 TEST(Proc, ParseNetwork) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
 
   proc.network_stats();
   EXPECT_TRUE(registry.Measurements().empty());
@@ -22,31 +23,32 @@ TEST(Proc, ParseNetwork) {
 
   const auto& ms = registry.Measurements();
   auto map = measurements_to_map(ms, "iface");
-  expect_value(&map, "net.iface.bytes|count|in|eth1", 1e3);
-  expect_value(&map, "net.iface.errors|count|in|eth1", 1);
-  expect_value(&map, "net.iface.packets|count|in|eth1", 1e3);
-  expect_value(&map, "net.iface.bytes|count|out|eth1", 1e6);
-  expect_value(&map, "net.iface.errors|count|out|eth1", 2);
-  expect_value(&map, "net.iface.packets|count|out|eth1", 1e4);
-  expect_value(&map, "net.iface.droppedPackets|count|out|eth1", 1);
-  expect_value(&map, "net.iface.bytes|count|in|lo", 1e5);
-  expect_value(&map, "net.iface.packets|count|in|lo", 1e7);
-  expect_value(&map, "net.iface.bytes|count|out|lo", 1e9);
-  expect_value(&map, "net.iface.packets|count|out|lo", 1e6);
-  expect_value(&map, "net.iface.packets|count|out|eth0", 1e6);
-  expect_value(&map, "net.iface.bytes|count|out|eth0", 1e8);
-  expect_value(&map, "net.iface.collisions|count|eth0", 1);
-  expect_value(&map, "net.iface.bytes|count|in|eth0", 1e5);
-  expect_value(&map, "net.iface.droppedPackets|count|out|eth0", 1);
-  expect_value(&map, "net.iface.errors|count|out|eth0", 2);
-  expect_value(&map, "net.iface.packets|count|in|eth0", 100);
+  expect_value(&map, "net.iface.bytes|count|in|eth1|extra", 1e3);
+  expect_value(&map, "net.iface.errors|count|in|eth1|extra", 1);
+  expect_value(&map, "net.iface.packets|count|in|eth1|extra", 1e3);
+  expect_value(&map, "net.iface.bytes|count|out|eth1|extra", 1e6);
+  expect_value(&map, "net.iface.errors|count|out|eth1|extra", 2);
+  expect_value(&map, "net.iface.packets|count|out|eth1|extra", 1e4);
+  expect_value(&map, "net.iface.droppedPackets|count|out|eth1|extra", 1);
+  expect_value(&map, "net.iface.bytes|count|in|lo|extra", 1e5);
+  expect_value(&map, "net.iface.packets|count|in|lo|extra", 1e7);
+  expect_value(&map, "net.iface.bytes|count|out|lo|extra", 1e9);
+  expect_value(&map, "net.iface.packets|count|out|lo|extra", 1e6);
+  expect_value(&map, "net.iface.packets|count|out|eth0|extra", 1e6);
+  expect_value(&map, "net.iface.bytes|count|out|eth0|extra", 1e8);
+  expect_value(&map, "net.iface.collisions|count|eth0|extra", 1);
+  expect_value(&map, "net.iface.bytes|count|in|eth0|extra", 1e5);
+  expect_value(&map, "net.iface.droppedPackets|count|out|eth0|extra", 1);
+  expect_value(&map, "net.iface.errors|count|out|eth0|extra", 2);
+  expect_value(&map, "net.iface.packets|count|in|eth0|extra", 100);
 
   EXPECT_TRUE(map.empty());  // checked all values
 }
 
 TEST(Proc, ParseSnmp) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
 
   proc.snmp_stats();
   // only gauges
@@ -59,54 +61,55 @@ TEST(Proc, ParseSnmp) {
 
   auto ms = registry.Measurements();
   measurement_map values = measurements_to_map(ms, "proto");
-  expect_value(&values, "net.tcp.connectionStates|gauge|closeWait|v4", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|closeWait|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|close|v4", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|close|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|closing|v4", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|closing|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|established|v4", 27);
-  expect_value(&values, "net.tcp.connectionStates|gauge|established|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|finWait1|v4", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|finWait1|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|finWait2|v4", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|finWait2|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|lastAck|v4", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|lastAck|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|listen|v4", 10);
-  expect_value(&values, "net.tcp.connectionStates|gauge|listen|v6", 5);
-  expect_value(&values, "net.tcp.connectionStates|gauge|synRecv|v4", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|synRecv|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|synSent|v4", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|synSent|v6", 0);
-  expect_value(&values, "net.tcp.connectionStates|gauge|timeWait|v4", 1);
-  expect_value(&values, "net.tcp.connectionStates|gauge|timeWait|v6", 0);
-  expect_value(&values, "net.tcp.currEstab|gauge", 27);
+  expect_value(&values, "net.tcp.connectionStates|gauge|closeWait|v4|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|closeWait|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|close|v4|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|close|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|closing|v4|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|closing|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|established|v4|extra", 27);
+  expect_value(&values, "net.tcp.connectionStates|gauge|established|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|finWait1|v4|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|finWait1|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|finWait2|v4|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|finWait2|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|lastAck|v4|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|lastAck|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|listen|v4|extra", 10);
+  expect_value(&values, "net.tcp.connectionStates|gauge|listen|v6|extra", 5);
+  expect_value(&values, "net.tcp.connectionStates|gauge|synRecv|v4|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|synRecv|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|synSent|v4|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|synSent|v6|extra", 0);
+  expect_value(&values, "net.tcp.connectionStates|gauge|timeWait|v4|extra", 1);
+  expect_value(&values, "net.tcp.connectionStates|gauge|timeWait|v6|extra", 0);
+  expect_value(&values, "net.tcp.currEstab|gauge|extra", 27);
 
-  expect_value(&values, "net.ip.datagrams|count|out", 20);
-  expect_value(&values, "net.ip.discards|count|out", 3);
-  expect_value(&values, "net.ip.datagrams|count|in", 100);
-  expect_value(&values, "net.ip.discards|count|in", 1);
+  expect_value(&values, "net.ip.datagrams|count|out|extra", 20);
+  expect_value(&values, "net.ip.discards|count|out|extra", 3);
+  expect_value(&values, "net.ip.datagrams|count|in|extra", 100);
+  expect_value(&values, "net.ip.discards|count|in|extra", 1);
 
-  expect_value(&values, "net.tcp.errors|count|attemptFails", 1);
-  expect_value(&values, "net.tcp.errors|count|estabResets", 10);
-  expect_value(&values, "net.tcp.errors|count|inErrs", 9);
-  expect_value(&values, "net.tcp.errors|count|outRsts", 2);
-  expect_value(&values, "net.tcp.errors|count|retransSegs", 20);
-  expect_value(&values, "net.tcp.opens|count|active", 100);
-  expect_value(&values, "net.tcp.opens|count|passive", 30);
-  expect_value(&values, "net.tcp.segments|count|in", 1e+06);
-  expect_value(&values, "net.tcp.segments|count|out", 1.1e+06);
+  expect_value(&values, "net.tcp.errors|count|attemptFails|extra", 1);
+  expect_value(&values, "net.tcp.errors|count|estabResets|extra", 10);
+  expect_value(&values, "net.tcp.errors|count|inErrs|extra", 9);
+  expect_value(&values, "net.tcp.errors|count|outRsts|extra", 2);
+  expect_value(&values, "net.tcp.errors|count|retransSegs|extra", 20);
+  expect_value(&values, "net.tcp.opens|count|active|extra", 100);
+  expect_value(&values, "net.tcp.opens|count|passive|extra", 30);
+  expect_value(&values, "net.tcp.segments|count|in|extra", 1e+06);
+  expect_value(&values, "net.tcp.segments|count|out|extra", 1.1e+06);
 
-  expect_value(&values, "net.udp.datagrams|count|in", 10000);
-  expect_value(&values, "net.udp.datagrams|count|out", 1000);
-  expect_value(&values, "net.udp.errors|count|inErrors", 1);
+  expect_value(&values, "net.udp.datagrams|count|in|extra", 10000);
+  expect_value(&values, "net.udp.datagrams|count|out|extra", 1000);
+  expect_value(&values, "net.udp.errors|count|inErrors|extra", 1);
   EXPECT_TRUE(values.empty());
 }
 
 TEST(Proc, ParseLoadAvg) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
   proc.loadavg_stats();
   const auto& ms = registry.Measurements();
   EXPECT_EQ(3, ms.size()) << "3 metrics for loadavg";
@@ -126,7 +129,9 @@ TEST(Proc, ParsePidFromSched) {
 
 TEST(Proc, IsContainer) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
+
   EXPECT_TRUE(proc.is_container());
   proc.set_prefix("./resources/proc-host");
   EXPECT_FALSE(proc.is_container());
@@ -140,7 +145,8 @@ bool is_gauge(const spectator::IdPtr& id) {
 
 TEST(Proc, CpuStats) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
   proc.cpu_stats();
   proc.peak_cpu_stats();
   const auto& ms = registry.Measurements();
@@ -155,7 +161,8 @@ TEST(Proc, CpuStats) {
 
 TEST(Proc, VmStats) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
   proc.vmstats();
   auto ms = registry.Measurements();
   auto ms_map = measurements_to_map(ms, "proto");
@@ -182,7 +189,8 @@ TEST(Proc, VmStats) {
 
 TEST(Proc, MemoryStats) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
   proc.memory_stats();
   auto ms = registry.Measurements();
   auto ms_map = measurements_to_map(ms, "proto");
@@ -200,7 +208,8 @@ TEST(Proc, MemoryStats) {
 
 TEST(Proc, ParseNetstat) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
   proc.netstat_stats();
   EXPECT_TRUE(registry.Measurements().empty());
 
@@ -209,26 +218,29 @@ TEST(Proc, ParseNetstat) {
 
   const auto& ms = registry.Measurements();
   measurement_map values = measurements_to_map(ms, "proto");
-  expect_value(&values, "net.ip.ectPackets|count|capable", 180.0);
-  expect_value(&values, "net.ip.ectPackets|count|notCapable", 60.0);
-  expect_value(&values, "net.ip.congestedPackets|count", 30);
+  expect_value(&values, "net.ip.ectPackets|count|capable|extra", 180.0);
+  expect_value(&values, "net.ip.ectPackets|count|notCapable|extra", 60.0);
+  expect_value(&values, "net.ip.congestedPackets|count|extra", 30);
   EXPECT_TRUE(values.empty());
 }
 
 TEST(Proc, ArpStats) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
   proc.arp_stats();
   const auto ms = registry.Measurements();
   EXPECT_EQ(ms.size(), 1);
   const auto& m = ms.front();
   EXPECT_EQ(m.id->Name(), "net.arpCacheSize");
+  EXPECT_EQ(m.id->GetTags().at("nf.test"), "extra");
   EXPECT_DOUBLE_EQ(m.value, 6);
 }
 
 TEST(Proc, ProcessStats) {
   Registry registry(GetConfiguration(), Logger());
-  Proc proc{&registry, "./resources/proc"};
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "./resources/proc"};
   proc.process_stats();
 
   const auto& ms = registry.Measurements();

--- a/test/utils_test.cc
+++ b/test/utils_test.cc
@@ -69,4 +69,8 @@ TEST(Utils, ParseTags) {
 TEST(Utils, ParseTagsEmpty) {
   auto tags = atlasagent::parse_tags("");
   EXPECT_EQ(tags.size(), 0);
+
+  auto some_invalid = atlasagent::parse_tags("key=val, key2=, =");
+  EXPECT_EQ(some_invalid.size(), 1);
+  EXPECT_EQ(some_invalid.at("key"), "val");
 }

--- a/test/utils_test.cc
+++ b/test/utils_test.cc
@@ -58,3 +58,15 @@ TEST(Utils, CanExecuteFullPath) {
   EXPECT_TRUE(atlasagent::can_execute("/bin/sh"));
   EXPECT_FALSE(atlasagent::can_execute("/bin/pr-does-not-exist"));
 }
+
+TEST(Utils, ParseTags) {
+  auto tags = atlasagent::parse_tags("key=value,key2=value2");
+  EXPECT_EQ(tags.size(), 2);
+  EXPECT_EQ(tags.at("key"), "value");
+  EXPECT_EQ(tags.at("key2"), "value2");
+}
+
+TEST(Utils, ParseTagsEmpty) {
+  auto tags = atlasagent::parse_tags("");
+  EXPECT_EQ(tags.size(), 0);
+}


### PR DESCRIPTION
Add a command line option to specify extra tags to add to network
related metrics. This could be extended in the future to tag the other
types as needed.