### PR TITLE
Add titus network bandwidth

### DIFF
--- a/lib/cgroup.cc
+++ b/lib/cgroup.cc
@@ -1,10 +1,22 @@
 #include "cgroup.h"
 #include "logger.h"
 #include "util.h"
-#include <spectator/id.h>
+#include <cstdlib>
 #include <map>
+#include <spectator/id.h>
 
 namespace atlasagent {
+
+void CGroup::network_stats() noexcept {
+  auto megabits = std::getenv("TITUS_NUM_NETWORK_BANDWIDTH");
+  if (megabits != nullptr) {
+    auto n = strtol(megabits, nullptr, 10);
+    if (n > 0) {
+      auto bytes = n * 125000.0;  // 1 megabit = 1,000,000 bits / 8 = 125,000 bytes
+      registry_->GetGauge("cgroup.net.bandwidthBytes")->Set(bytes);
+    }
+  }
+}
 
 void CGroup::cpu_shares(time_point now) noexcept {
   auto shares = read_num_from_file(path_prefix_, "cpu/cpu.shares");

--- a/lib/cgroup.h
+++ b/lib/cgroup.h
@@ -12,6 +12,7 @@ class CGroup {
                   std::chrono::seconds update_interval = std::chrono::seconds{60}) noexcept;
   void cpu_stats() noexcept;
   void memory_stats() noexcept;
+  void network_stats() noexcept;
   void set_prefix(std::string new_prefix) noexcept { path_prefix_ = std::move(new_prefix); }
 
  private:


### PR DESCRIPTION
Adds a gauge to track the network bandwidth allocated to titus
containers. Titus exports an environment variable reported in megabits/s
but to be consistent with our base units we transform it to bytes/s