### PR TITLE
Timeout when getting input from external commands

### DIFF
--- a/lib/files.h
+++ b/lib/files.h
@@ -31,32 +31,6 @@ class StdIoFile {
   char buf[65536];
 };
 
-class StdPipe {
- public:
-  explicit StdPipe(const char* cmd) noexcept : fp_(::popen(cmd, "r")) {
-    if (fp_ == nullptr) {
-      Logger()->warn("Unable to execute {}", cmd);
-    } else {
-      setbuffer(fp_, buf, sizeof buf);
-    }
-  }
-  StdPipe(const StdPipe&) = delete;
-  StdPipe(StdPipe&& other) noexcept : fp_(other.fp_) { other.fp_ = nullptr; }
-
-  ~StdPipe() {
-    if (fp_ != nullptr) {
-      ::pclose(fp_);
-      fp_ = nullptr;
-    }
-  }
-
-  operator FILE*() const { return fp_; }
-
- private:
-  FILE* fp_;
-  char buf[65536];
-};
-
 class UnixFile {
  public:
   explicit UnixFile(int fd) : fd_(fd) {}
@@ -92,7 +66,7 @@ class UnixFile {
 
 class DirHandle {
  public:
-  explicit DirHandle(const char* name) noexcept : dh_{ opendir(name)} {
+  explicit DirHandle(const char* name) noexcept : dh_{opendir(name)} {
     if (dh_ == nullptr) {
       Logger()->warn("Unable to opendir {}: {}", name, strerror(errno));
     }

--- a/lib/util.h
+++ b/lib/util.h
@@ -22,10 +22,10 @@ void split(const char* line, const std::function<bool(int)>& is_sep,
 bool starts_with(const char* line, const char* prefix) noexcept;
 
 // Execute cmd using the shell, and return its output as a string
-std::string read_output_string(const char* cmd);
+std::string read_output_string(const char* cmd, int timeout_millis = 1000);
 
 // Execute cmd using the shell and return its output as a vector of lines
-std::vector<std::string> read_output_lines(const char* cmd);
+std::vector<std::string> read_output_lines(const char* cmd, int timeout_millis = 1000);
 
 // determine whether the program passed is available
 bool can_execute(const std::string& program);

--- a/test/utils_test.cc
+++ b/test/utils_test.cc
@@ -3,6 +3,7 @@
 
 #include "../lib/util.h"
 
+namespace {
 std::vector<std::string> expected = {"foo:", "bar", "baz", "43.2", "x&z"};
 TEST(Utils, SplitEmpty) {
   std::vector<std::string> res;
@@ -35,8 +36,18 @@ TEST(Utils, ReadOutputString) {
 
 TEST(Utils, ReadOutputLines) {
   auto lines = atlasagent::read_output_lines("echo first line;echo second line;echo third line");
-  std::vector<std::string> expected = {"first line\n", "second line\n", "third line\n"};
+  std::vector<std::string> expected = {"first line", "second line", "third line"};
   EXPECT_EQ(lines, expected);
+}
+
+TEST(Utils, ReadOutputTimeoutNoInput) {
+  auto lines = atlasagent::read_output_lines("sleep 4; echo hi", 10);
+  EXPECT_TRUE(lines.empty());
+}
+
+TEST(Utils, ReadOutputTimeoutAfterInput) {
+  auto lines = atlasagent::read_output_lines("echo foo; sleep 1; echo bar", 10);
+  EXPECT_TRUE(lines.empty());
 }
 
 TEST(Utils, ReadOutputStringErr) {
@@ -74,3 +85,4 @@ TEST(Utils, ParseTagsEmpty) {
   EXPECT_EQ(some_invalid.size(), 1);
   EXPECT_EQ(some_invalid.at("key"), "val");
 }
+}  // namespace


### PR DESCRIPTION
This fixes issue #72: now when an external command is hanging and we
cannot get its output in time we just return an empty string to the
caller.

Note that we cannot simply keep using `popen` under the hood since
`pclose` will wait until the program exits, so it does us no good to
timeout the reads. We need to manually create the pipe and kill the
child when we timeout