### PR TITLE
Do not prefix disk metrics with cgroup for titus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
   - gcc
 env:
   global:
-    - SPECTATOR_CPP_VERSION=v0.7.6
+    - SPECTATOR_CPP_VERSION=v0.8.0
   matrix:
     - TITUS_AGENT="-DTITUS_AGENT=ON .."
     - TITUS_AGENT=""

--- a/lib/disk.h
+++ b/lib/disk.h
@@ -55,10 +55,7 @@ class Disk {
   std::vector<MountPoint> get_mount_points() const noexcept;
   std::vector<DiskIo> get_disk_stats() const noexcept;
   void update_titus_stats_for(const MountPoint& mp) noexcept;
-  void update_stats_for(const MountPoint& mp, const char* prefix) noexcept;
-
-  void update_gauge(const char* prefix, const char* name, const spectator::Tags& tags,
-                    double value) noexcept;
+  void update_stats_for(const MountPoint& mp) noexcept;
 
   void diskio_stats(spectator::Registry::clock::time_point start) noexcept;
   void set_last_updated(spectator::Registry::clock::time_point updated) { last_updated_ = updated; }

--- a/lib/proc.cc
+++ b/lib/proc.cc
@@ -124,9 +124,9 @@ void sum_tcp_states(FILE* fp, std::array<int, kConnStates>* connections) noexcep
 
 using gauge_ptr = std::shared_ptr<spectator::Gauge>;
 
-inline IdPtr create_id(Registry* registry, const char* name, const Tags& tags, const Tags& extra) {
+inline IdPtr create_id(Registry* registry, const char* name, const Tags& tags, Tags extra) {
   Tags all_tags{tags};
-  all_tags.add_all(extra);
+  all_tags.move_all(std::move(extra));
   return registry->CreateId(name, all_tags);
 }
 

--- a/test/disk_test.cc
+++ b/test/disk_test.cc
@@ -101,7 +101,7 @@ TEST(Disk, UpdateTitusStats) {
 
   disk.titus_disk_stats();
 
-  const auto& ms = registry.Measurements();
+  const auto& ms = my_measurements(&registry);
   for (const auto& m : ms) {
     Logger()->info("Got {}", m);
   }
@@ -115,12 +115,12 @@ TEST(Disk, UpdateDiskStats) {
   disk.do_disk_stats(start);
   disk.set_last_updated(start);
 
-  auto initial = registry.Measurements();
+  auto initial = my_measurements(&registry);
 
   disk.set_prefix("./resources2");
   disk.do_disk_stats(start + std::chrono::seconds(5));
 
-  auto ms = registry.Measurements();
+  auto ms = my_measurements(&registry);
   auto values = measurements_to_map(ms, "dev");
   expect_value(&values, "disk.io.bytes|count|read|md0", 512 * 1e4);
   expect_value(&values, "disk.io.bytes|count|read|xvda", 512 * 1e4);
@@ -165,13 +165,13 @@ TEST(Disk, diskio_stats) {
 
   auto start = spectator::Registry::clock::now();
   disk.diskio_stats(start);
-  auto initial = registry.Measurements();
+  auto initial = my_measurements(&registry);
   EXPECT_TRUE(initial.empty());
 
   disk.set_prefix("./resources2");
   disk.diskio_stats(start + std::chrono::seconds{60});
 
-  auto ms = registry.Measurements();
+  auto ms = my_measurements(&registry);
   auto values = measurements_to_map(ms, "dev");
   expect_value(&values, "disk.io.bytes|count|read|md0", 512 * 1e4);
   expect_value(&values, "disk.io.bytes|count|read|xvda", 512 * 1e4);

--- a/test/measurement_utils.h
+++ b/test/measurement_utils.h
@@ -3,6 +3,7 @@
 #include <spectator/measurement.h>
 #include <unordered_map>
 #include <vector>
+#include <spectator/registry.h>
 
 using measurement_map = std::unordered_map<std::string, double>;
 measurement_map measurements_to_map(const std::vector<spectator::Measurement>& ms,
@@ -11,3 +12,12 @@ measurement_map measurements_to_map(const std::vector<spectator::Measurement>& m
 // removes the entry after doing the comparison so we can later iterate over all measurements
 // that were generated but have not been asserted
 void expect_value(measurement_map* measurements, const char* name, double expected);
+
+inline std::vector<spectator::Measurement> my_measurements(spectator::Registry* registry) {
+  auto ms = registry->Measurements();
+  std::vector<spectator::Measurement> result;
+  std::copy_if(
+      ms.begin(), ms.end(), std::back_inserter(result),
+      [](const spectator::Measurement& m) { return m.id->Name().rfind("spectator.", 0) != 0; });
+  return result;
+}

--- a/test/monotonic_timer_test.cc
+++ b/test/monotonic_timer_test.cc
@@ -3,6 +3,7 @@
 #include "../lib/monotonic_timer.h"
 #include "measurement_utils.h"
 
+namespace {
 TEST(MonotonicTimer, NoActivity) {
   spectator::Registry registry{spectator::GetConfiguration(), spectator::DefaultLogger()};
   MonotonicTimer timer{&registry, registry.CreateId("test", spectator::Tags{})};
@@ -32,12 +33,13 @@ TEST(MonotonicTimer, Overflow) {
 
   using millis = std::chrono::milliseconds;
   timer.update(millis{2000}, 10);
-  EXPECT_EQ(registry.Measurements().size(), 0);
+  EXPECT_EQ(my_measurements(&registry).size(), 0);
   timer.update(millis{1000}, 15);  // overflow time
-  EXPECT_EQ(registry.Measurements().size(), 0);
+  EXPECT_EQ(my_measurements(&registry).size(), 0);
   timer.update(millis{3000}, 12);  // overflow count
-  EXPECT_EQ(registry.Measurements().size(), 0);
+  EXPECT_EQ(my_measurements(&registry).size(), 0);
 
   timer.update(millis{4000}, 13);  // back to normal
-  EXPECT_EQ(registry.Measurements().size(), 2);
+  EXPECT_EQ(my_measurements(&registry).size(), 2);
 }
+}  // namespace

--- a/test/proc_test.cc
+++ b/test/proc_test.cc
@@ -16,12 +16,12 @@ TEST(Proc, ParseNetwork) {
   Proc proc{&registry, extra, "./resources/proc"};
 
   proc.network_stats();
-  EXPECT_TRUE(registry.Measurements().empty());
+  EXPECT_TRUE(my_measurements(&registry).empty());
 
   proc.set_prefix("./resources/proc2");
   proc.network_stats();
 
-  const auto& ms = registry.Measurements();
+  const auto& ms = my_measurements(&registry);
   auto map = measurements_to_map(ms, "iface");
   expect_value(&map, "net.iface.bytes|count|in|eth1|extra", 1e3);
   expect_value(&map, "net.iface.errors|count|in|eth1|extra", 1);
@@ -52,14 +52,14 @@ TEST(Proc, ParseSnmp) {
 
   proc.snmp_stats();
   // only gauges
-  auto initial = registry.Measurements();
+  auto initial = my_measurements(&registry);
   for (const auto& m : initial) {
     EXPECT_EQ(m.id->GetTags().at("statistic"), "gauge");
   }
   proc.set_prefix("./resources/proc2");
   proc.snmp_stats();
 
-  auto ms = registry.Measurements();
+  auto ms = my_measurements(&registry);
   measurement_map values = measurements_to_map(ms, "proto");
   expect_value(&values, "net.tcp.connectionStates|gauge|closeWait|v4|extra", 0);
   expect_value(&values, "net.tcp.connectionStates|gauge|closeWait|v6|extra", 0);
@@ -111,7 +111,7 @@ TEST(Proc, ParseLoadAvg) {
   spectator::Tags extra{{"nf.test", "extra"}};
   Proc proc{&registry, extra, "./resources/proc"};
   proc.loadavg_stats();
-  const auto& ms = registry.Measurements();
+  const auto& ms = my_measurements(&registry);
   EXPECT_EQ(3, ms.size()) << "3 metrics for loadavg";
 
   for (const auto& m : ms) {
@@ -149,13 +149,13 @@ TEST(Proc, CpuStats) {
   Proc proc{&registry, extra, "./resources/proc"};
   proc.cpu_stats();
   proc.peak_cpu_stats();
-  const auto& ms = registry.Measurements();
+  const auto& ms = my_measurements(&registry);
   EXPECT_TRUE(ms.empty());
 
   proc.set_prefix("./resources/proc2");
   proc.cpu_stats();
   proc.peak_cpu_stats();
-  const auto& ms2 = registry.Measurements();
+  const auto& ms2 = my_measurements(&registry);
   EXPECT_EQ(16, ms2.size());
 }
 
@@ -164,7 +164,7 @@ TEST(Proc, VmStats) {
   spectator::Tags extra{{"nf.test", "extra"}};
   Proc proc{&registry, extra, "./resources/proc"};
   proc.vmstats();
-  auto ms = registry.Measurements();
+  auto ms = my_measurements(&registry);
   auto ms_map = measurements_to_map(ms, "proto");
   expect_value(&ms_map, "vmstat.procs|gauge|blocked", 1);
   expect_value(&ms_map, "vmstat.procs|gauge|running", 2);
@@ -174,7 +174,7 @@ TEST(Proc, VmStats) {
 
   proc.set_prefix("./resources/proc2");
   proc.vmstats();
-  auto ms2 = registry.Measurements();
+  auto ms2 = my_measurements(&registry);
   auto ms2_map = measurements_to_map(ms2, "proto");
   expect_value(&ms2_map, "vmstat.procs|gauge|blocked", 2);
   expect_value(&ms2_map, "vmstat.procs|gauge|running", 3);
@@ -192,7 +192,7 @@ TEST(Proc, MemoryStats) {
   spectator::Tags extra{{"nf.test", "extra"}};
   Proc proc{&registry, extra, "./resources/proc"};
   proc.memory_stats();
-  auto ms = registry.Measurements();
+  auto ms = my_measurements(&registry);
   auto ms_map = measurements_to_map(ms, "proto");
   expect_value(&ms_map, "mem.freeReal|gauge", 1024.0 * 9631224);
   expect_value(&ms_map, "mem.availReal|gauge", 1024.0 * 9557144);
@@ -211,12 +211,12 @@ TEST(Proc, ParseNetstat) {
   spectator::Tags extra{{"nf.test", "extra"}};
   Proc proc{&registry, extra, "./resources/proc"};
   proc.netstat_stats();
-  EXPECT_TRUE(registry.Measurements().empty());
+  EXPECT_TRUE(my_measurements(&registry).empty());
 
   proc.set_prefix("./resources/proc2");
   proc.netstat_stats();
 
-  const auto& ms = registry.Measurements();
+  const auto& ms = my_measurements(&registry);
   measurement_map values = measurements_to_map(ms, "proto");
   expect_value(&values, "net.ip.ectPackets|count|capable|extra", 180.0);
   expect_value(&values, "net.ip.ectPackets|count|notCapable|extra", 60.0);
@@ -229,7 +229,7 @@ TEST(Proc, ArpStats) {
   spectator::Tags extra{{"nf.test", "extra"}};
   Proc proc{&registry, extra, "./resources/proc"};
   proc.arp_stats();
-  const auto ms = registry.Measurements();
+  const auto ms = my_measurements(&registry);
   EXPECT_EQ(ms.size(), 1);
   const auto& m = ms.front();
   EXPECT_EQ(m.id->Name(), "net.arpCacheSize");
@@ -243,7 +243,7 @@ TEST(Proc, ProcessStats) {
   Proc proc{&registry, extra, "./resources/proc"};
   proc.process_stats();
 
-  const auto& ms = registry.Measurements();
+  const auto& ms = my_measurements(&registry);
   auto map = measurements_to_map(ms, "");
   expect_value(&map, "sys.currentProcesses|gauge", 2.0);
   expect_value(&map, "sys.currentThreads|gauge", 1.0 + 4.0);


### PR DESCRIPTION
The titus agent prefixed metrics with `cgroup.` for historical reasons.
Remove this prefix so they're consistent in naming with the system-agent
metrics that represent the same concepts

Update to spectator-cpp 0.8.0