### PR TITLE
Initialize the last sample time to now

### DIFF
--- a/lib/ntp.h
+++ b/lib/ntp.h
@@ -12,7 +12,8 @@ class Ntp {
   explicit Ntp(spectator::Registry* registry) noexcept
       : lastSampleAge_{registry->GetGauge("sys.time.lastSampleAge")},
         estimatedError_{registry->GetGauge("sys.time.estimatedError")},
-        unsynchronized_{registry->GetGauge("sys.time.unsynchronized")} {}
+        unsynchronized_{registry->GetGauge("sys.time.unsynchronized")},
+        lastSampleTime_{Clock::now()} {}
 
   void update_stats() noexcept {
     if (can_execute("chronyc")) {
@@ -34,7 +35,7 @@ class Ntp {
 
  protected:
   // for testing
-  typename Clock::time_point lastSampleTime_{};
+  typename Clock::time_point lastSampleTime_;
 
   void ntp_stats(int err, timex* time) {
     if (err == -1) {

--- a/test/ntp_test.cc
+++ b/test/ntp_test.cc
@@ -3,6 +3,7 @@
 #include "measurement_utils.h"
 #include <gtest/gtest.h>
 
+namespace {
 using atlasagent::Logger;
 using atlasagent::Ntp;
 
@@ -133,3 +134,4 @@ TEST(Ntp, adjtime_err) {
                                                       {"sys.time.estimatedError|gauge", 0.2}};
   EXPECT_EQ(map, expected);
 }
+}  // namespace


### PR DESCRIPTION
In order to avoid spikes that might happen during initialization, set
the sample time to now. Otherwise we might report a last sample age for
ntp that is basically now() - 0