### PR TITLE
Fix path for cpu frequency files

### DIFF
--- a/lib/cpufreq.h
+++ b/lib/cpufreq.h
@@ -6,7 +6,7 @@ namespace atlasagent {
 class CpuFreq {
  public:
   explicit CpuFreq(spectator::Registry* registry,
-                   std::string path_prefix = "/sys/devices/system/cpu") noexcept;
+                   std::string path_prefix = "/sys/devices/system/cpu/cpufreq") noexcept;
 
   void Stats() noexcept;
 


### PR DESCRIPTION
The default path which is used during normal operations was wrong
(mainly due to an update to make the test resources easy to find)