### PR TITLE
Update spectator-cpp dependency to retry on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An agent that reports metrics for ec2 instances or titus containers.
 ## Build Instructions
 
 * This build requires a C++17 compiler and uses [bazel](https://bazel.build/)
-  as its build system. This has been tested with clang 11 and g++ 10
+  as its build system. This has been tested with clang 11, g++ 7, and g++ 10.
 
 * [Install bazel](https://docs.bazel.build/versions/master/install.html)
 

--- a/dependencies.bzl
+++ b/dependencies.bzl
@@ -3,9 +3,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def nflx_atlas_sysagent():
     http_archive(
         name = "spectator",
-        urls = ["https://github.com/Netflix/spectator-cpp/archive/26d556fbb9545c2a4a1ea0fa6aec703091348d7e.zip"],
-        strip_prefix = "spectator-cpp-26d556fbb9545c2a4a1ea0fa6aec703091348d7e",
-        sha256 = "c814674427ac275bf135ac4f9d54eda4c157d29c8201a749451e9032135667ed",
+        urls = ["https://github.com/Netflix/spectator-cpp/archive/9142a540c902b91b11afd7f89981dd833f15914f.zip"],
+        strip_prefix = "spectator-cpp-9142a540c902b91b11afd7f89981dd833f15914f",
+        sha256 = "42d708f3b5c4d2a89edd70c8f495e7b85f590c06ff3e04b9564d4a857e52aa68"
     )
 
     # GoogleTest/GoogleMock framework.


### PR DESCRIPTION
The latest spectator-cpp will handle temporary connection errors
when talking to spectatord