### PR TITLE
Add the ability to tag metrics based on their name

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,6 +42,8 @@ cc_library(
         "lib/nvml.h",
         "lib/perfmetrics.h",
         "lib/proc.h",
+        "lib/tagger.h",
+        "lib/tagging_registry.h",
         "lib/util.h",
     ],
     defines = select({

--- a/lib/aws.h
+++ b/lib/aws.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <rapidjson/document.h>
 #include "http_client.h"
 #include "logger.h"
-#include "spectator/registry.h"
+#include "tagging_registry.h"
+#include <rapidjson/document.h>
 
 namespace atlasagent {
 
@@ -28,7 +28,7 @@ inline absl::Time getDateFrom(const rapidjson::Document& doc, const char* dateSt
 
 }  // namespace detail
 
-template <typename Reg = spectator::Registry>
+template <typename Reg = TaggingRegistry>
 class Aws {
  public:
   explicit Aws(Reg* registry) noexcept

--- a/lib/cgroup.h
+++ b/lib/cgroup.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "spectator/registry.h"
+#include "tagging_registry.h"
 
 namespace atlasagent {
 
-template <typename Reg = spectator::Registry>
+template <typename Reg = TaggingRegistry>
 class CGroup {
  public:
   explicit CGroup(Reg* registry, std::string path_prefix = "/sys/fs/cgroup",

--- a/lib/cpufreq.h
+++ b/lib/cpufreq.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "files.h"
+#include "tagging_registry.h"
 #include "util.h"
-#include "spectator/registry.h"
 #include <sys/stat.h>
 
 namespace atlasagent {
@@ -18,7 +18,7 @@ inline bool is_directory(const std::string& directory) {
 }
 }  // namespace detail
 
-template <typename Reg = spectator::Registry>
+template <typename Reg = TaggingRegistry>
 class CpuFreq {
  public:
   explicit CpuFreq(Reg* registry,

--- a/lib/disk.h
+++ b/lib/disk.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "monotonic_timer.h"
-#include "spectator/registry.h"
+#include "tagging_registry.h"
 #include <string>
 #include <sys/types.h>
 #include <unordered_map>
@@ -33,7 +33,7 @@ struct DiskIo {
   u_long weighted_ms_doing_io;
 };
 
-template <typename Reg = spectator::Registry>
+template <typename Reg = TaggingRegistry>
 class Disk {
  public:
   explicit Disk(Reg* registry, std::string path_prefix = "") noexcept

--- a/lib/internal/proc.inc
+++ b/lib/internal/proc.inc
@@ -219,7 +219,8 @@ void Proc<Reg>::parse_ipv6_stats(
       create_id("net.ip.ectPackets", {{"id", "capable"}, {"proto", "v6"}}, net_tags_));
   static auto noEct_ctr = registry_->GetMonotonicCounter(
       create_id("net.ip.ectPackets", {{"id", "notCapable"}, {"proto", "v6"}}, net_tags_));
-  static auto congested_ctr = registry_->GetMonotonicCounter(create_id("net.ip.congestedPackets", {{"proto", "v6"}}, net_tags_));
+  static auto congested_ctr = registry_->GetMonotonicCounter(
+      create_id("net.ip.congestedPackets", {{"proto", "v6"}}, net_tags_));
 
   auto in_receives = snmp_stats.find("Ip6InReceives");
   auto in_discards = snmp_stats.find("Ip6InDiscards");
@@ -760,7 +761,8 @@ void Proc<Reg>::netstat_stats() noexcept {
       create_id("net.ip.ectPackets", {{"id", "capable"}, {"proto", "v4"}}, net_tags_));
   static auto noEct_ctr = registry_->GetMonotonicCounter(
       create_id("net.ip.ectPackets", {{"id", "notCapable"}, {"proto", "v4"}}, net_tags_));
-  static auto congested_ctr = registry_->GetMonotonicCounter(create_id("net.ip.congestedPackets", {{"proto", "v4"}}, net_tags_));
+  static auto congested_ctr = registry_->GetMonotonicCounter(
+      create_id("net.ip.congestedPackets", {{"proto", "v4"}}, net_tags_));
 
   auto fp = open_file(path_prefix_, "net/netstat");
   if (fp == nullptr) {

--- a/lib/log_entry.h
+++ b/lib/log_entry.h
@@ -34,9 +34,10 @@ inline std::string_view path_from(std::string_view url) noexcept {
 
 }  // namespace detail
 
+template <typename Reg>
 class LogEntry {
  public:
-  LogEntry(spectator::Registry* registry, const std::string& method, const std::string& url)
+  LogEntry(Reg* registry, const std::string& method, const std::string& url)
       : registry_{registry},
         start_{absl::Now()},
         id_{spectator::Id::of("ipc.client.call", {{"owner", "spectator-cpp"},
@@ -68,7 +69,7 @@ class LogEntry {
   }
 
  private:
-  spectator::Registry* registry_;
+  Reg* registry_;
   absl::Time start_;
   spectator::IdPtr id_;
 

--- a/lib/ntp.h
+++ b/lib/ntp.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "tagging_registry.h"
 #include "util.h"
 #include "absl/strings/str_split.h"
-#include "spectator/registry.h"
 #include <sys/timex.h>
 
 namespace atlasagent {
@@ -13,7 +13,7 @@ struct abseil_clock {
 };
 }  // namespace detail
 
-template <typename Reg = spectator::Registry, typename Clock = detail::abseil_clock>
+template <typename Reg = TaggingRegistry, typename Clock = detail::abseil_clock>
 class Ntp {
  public:
   explicit Ntp(Reg* registry) noexcept

--- a/lib/perfmetrics.h
+++ b/lib/perfmetrics.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "spectator/registry.h"
+#include "tagging_registry.h"
 #include "util.h"
 #include <fmt/format.h>
 #include <unistd.h>
@@ -206,7 +206,7 @@ class PerfCounter {
   std::vector<perf_count> prev_vals;
 };
 
-template <typename Reg = spectator::Registry>
+template <typename Reg = TaggingRegistry>
 class PerfMetrics {
  public:
   PerfMetrics(Reg* registry, std::string path_prefix)

--- a/lib/proc.h
+++ b/lib/proc.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "spectator/registry.h"
+#include "tagging_registry.h"
 
 namespace atlasagent {
-template <typename Reg = spectator::Registry>
+template <typename Reg = TaggingRegistry>
 class Proc {
  public:
   Proc(Reg* registry, spectator::Tags net_tags, std::string path_prefix = "/proc") noexcept

--- a/lib/tagger.h
+++ b/lib/tagger.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include "files.h"
+#include "logger.h"
+#include "spectator/id.h"
+#include <fmt/format.h>
+#include <rapidjson/document.h>
+#include <rapidjson/error/en.h>
+#include <rapidjson/filereadstream.h>
+#include <string_view>
+
+namespace atlasagent {
+
+enum class TagRuleOp { Prefix, Name };
+
+class Tagger {
+ public:
+  static auto Nop() -> Tagger { return Tagger{{}}; }
+
+  static auto FromJson(const rapidjson::Document& doc) -> std::optional<Tagger> {
+    auto logger = Logger();
+    if (!doc.IsObject()) {
+      logger->error("Invalid config file. Should be a JSON object");
+      return {};
+    }
+
+    std::vector<Tagger::Rule> rules;
+    if (doc.HasMember("tag_rules")) {
+      auto jsonRules = doc["tag_rules"].GetArray();
+      for (const auto& jsonRule : jsonRules) {
+        auto op = TagRuleOp::Name;
+        std::string match;
+        if (jsonRule.HasMember("prefix")) {
+          op = TagRuleOp::Prefix;
+          match = jsonRule["prefix"].GetString();
+        } else if (jsonRule.HasMember("name")) {
+          match = jsonRule["name"].GetString();
+        } else {
+          logger->error("Invalid tag rule. Need 'name' or 'prefix'");
+          return {};
+        }
+
+        // parse tags
+        if (!jsonRule.HasMember("tags")) {
+          logger->error("Rule with {} = {} must include tags to add", op, match);
+          return {};
+        }
+
+        spectator::Tags tags;
+        auto jsonTags = jsonRule["tags"].GetObject();
+        for (const auto& kv : jsonTags) {
+          auto k = kv.name.GetString();
+          auto v = kv.value.GetString();
+          tags.add(k, v);
+        }
+
+        rules.emplace_back(op, match, std::move(tags));
+      }
+    }
+
+    return Tagger{std::move(rules)};
+  }
+
+  static auto FromConfigFile(const char* file) -> std::optional<Tagger> {
+    if (access(file, R_OK) == -1) {
+      return Tagger::Nop();
+    }
+
+    StdIoFile fp{file};
+    if (!fp) {
+      return {};
+    }
+
+    rapidjson::Document doc;
+    char buf[64 * 1024];
+    rapidjson::FileReadStream is(fp, buf, sizeof buf);
+    doc.ParseStream(is);
+    if (doc.HasParseError()) {
+      Logger()->error("Invalid config file. Parse error at offset {}: {}", doc.GetErrorOffset(),
+                      rapidjson::GetParseError_En(doc.GetParseError()));
+      return {};
+    }
+
+    return FromJson(doc);
+  }
+
+  class Rule {
+   public:
+    Rule(TagRuleOp op, std::string_view match, spectator::Tags tags)
+        : op_{op}, match_{match}, tags_{std::move(tags)} {}
+
+    auto Op() const -> TagRuleOp { return op_; }
+    auto Match() const -> const std::string& { return match_; }
+    auto Tags() const -> const spectator::Tags& { return tags_; }
+
+    auto operator==(const Rule& that) const -> bool {
+      return op_ == that.op_ && match_ == that.match_ && tags_ == that.tags_;
+    }
+
+    auto Matches(const spectator::Id& id) const -> bool {
+      if (op_ == TagRuleOp::Name) {
+        return id.Name() == match_;
+      }
+      // startsWith()
+      return id.Name().rfind(match_, 0) == 0;
+    }
+
+   private:
+    TagRuleOp op_;
+    std::string match_;
+    spectator::Tags tags_;
+  };
+
+  explicit Tagger(std::vector<Rule> rules) : rules_{std::move(rules)} {}
+  Tagger(const Tagger&) = default;
+  Tagger(Tagger&&) = default;
+  Tagger& operator=(Tagger&&) = default;
+  Tagger& operator=(const Tagger&) = default;
+  ~Tagger() = default;
+
+  auto GetRules() const -> const std::vector<Rule>& { return rules_; }
+
+  auto operator==(const Tagger& that) const -> bool { return that.GetRules() == rules_; }
+
+  auto GetId(spectator::IdPtr id) const -> spectator::IdPtr {
+    for (const auto& rule : rules_) {
+      if (rule.Matches(*id)) {
+        return id->WithTags(rule.Tags());
+      }
+    }
+    return id;
+  }
+
+  auto GetId(std::string_view name, spectator::Tags tags = {}) const -> spectator::IdPtr {
+    return GetId(spectator::Id::of(name, std::move(tags)));
+  }
+
+ private:
+  std::vector<Rule> rules_;
+};
+}  // namespace atlasagent
+
+// for debugging
+template <>
+struct fmt::formatter<atlasagent::TagRuleOp> {
+  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const atlasagent::TagRuleOp& op, FormatContext& context) {
+    return fmt::format_to(context.out(), "op={}",
+                          op == atlasagent::TagRuleOp::Name ? "name" : "prefix");
+  }
+};
+
+template <>
+struct fmt::formatter<atlasagent::Tagger::Rule> {
+  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const atlasagent::Tagger::Rule& rule, FormatContext& context) {
+    return fmt::format_to(context.out(), "rule({} -> {}, tags={})", rule.Op(), rule.Match(),
+                          rule.Tags());
+  }
+};
+
+template <>
+struct fmt::formatter<atlasagent::Tagger> {
+  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const atlasagent::Tagger& tagger, FormatContext& context) {
+    return fmt::format_to(context.out(), "tagger(rules={})", tagger.GetRules());
+  }
+};

--- a/lib/tagger_test.cc
+++ b/lib/tagger_test.cc
@@ -1,0 +1,43 @@
+#include "tagger.h"
+#include <gtest/gtest.h>
+
+namespace {
+
+using atlasagent::Tagger;
+using atlasagent::TagRuleOp;
+
+TEST(Tagger, FromCfgFile) {
+  auto tagger = Tagger::FromConfigFile("testdata/resources/atlas-agent.json");
+  std::vector<Tagger::Rule> expected;
+  spectator::Tags tags{{"tag-key1", "tag-val1"}, {"tag-key2", "tag-val2"}};
+  expected.emplace_back(TagRuleOp::Prefix, "disk.io.", tags);
+  expected.emplace_back(TagRuleOp::Name, "net.iface.bytes", tags);
+
+  Tagger expected_tagger{expected};
+  ASSERT_EQ(expected_tagger, tagger);
+  atlasagent::Logger()->debug("Got {} from config file", *tagger);
+}
+
+TEST(Tagger, AddTags) {
+  auto tagger = Tagger::FromConfigFile("testdata/resources/atlas-agent.json");
+  auto id_prefix = std::make_unique<spectator::Id>("disk.io.foo", spectator::Tags{{"dev", "root"}});
+  auto id_name =
+      std::make_unique<spectator::Id>("net.iface.bytes", spectator::Tags{{"dev", "eth0"}});
+  // match is for prefix = disk.io.
+  auto id_no_match = std::make_unique<spectator::Id>("disk.io", spectator::Tags({{"dev", "sda"}}));
+
+  auto id_prefix_tagged = tagger->GetId(std::move(id_prefix));
+  auto id_name_tagged = tagger->GetId(std::move(id_name));
+  auto id_no_match_tagged = tagger->GetId(std::move(id_no_match));
+
+  auto expected_disk_tags =
+      spectator::Tags{{"dev", "root"}, {"tag-key1", "tag-val1"}, {"tag-key2", "tag-val2"}};
+  auto expected_net_tags =
+      spectator::Tags{{"dev", "eth0"}, {"tag-key1", "tag-val1"}, {"tag-key2", "tag-val2"}};
+  auto expected_unchanged = spectator::Tags{{"dev", "sda"}};
+
+  EXPECT_EQ(id_prefix_tagged->GetTags(), expected_disk_tags);
+  EXPECT_EQ(id_name_tagged->GetTags(), expected_net_tags);
+  EXPECT_EQ(id_no_match_tagged->GetTags(), expected_unchanged);
+}
+}  // namespace

--- a/lib/tagging_registry.h
+++ b/lib/tagging_registry.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "tagger.h"
+#include "spectator/registry.h"
+
+namespace atlasagent {
+
+/// Wrap a spectator registry to be able to add some tags based on
+/// metric names
+template <typename Reg>
+class base_tagging_registry {
+ public:
+  base_tagging_registry(Reg* registry, Tagger tagger)
+      : registry_{registry}, tagger_{std::move(tagger)} {}
+  base_tagging_registry(const base_tagging_registry&) = default;
+  ~base_tagging_registry() = default;
+
+  auto GetCounter(std::string_view name, spectator::Tags tags = {}) {
+    return registry_->GetCounter(tagger_.GetId(name, std::move(tags)));
+  }
+  auto GetCounter(const spectator::IdPtr& id) { return registry_->GetCounter(tagger_.GetId(id)); }
+  auto GetDistributionSummary(std::string_view name, spectator::Tags tags = {}) {
+    return registry_->GetDistributionSummary(tagger_.GetId(name, std::move(tags)));
+  }
+  auto GetDistributionSummary(const spectator::IdPtr& id) {
+    return registry_->GetDistributionSummary(tagger_.GetId(id));
+  }
+  auto GetGauge(std::string_view name, spectator::Tags tags = {}) {
+    return registry_->GetGauge(tagger_.GetId(name, std::move(tags)));
+  }
+  auto GetGauge(const spectator::IdPtr& id) { return registry_->GetGauge(tagger_.GetId(id)); }
+  auto GetMaxGauge(std::string_view name, spectator::Tags tags = {}) {
+    return registry_->GetMaxGauge(tagger_.GetId(name, std::move(tags)));
+  }
+  auto GetMaxGauge(const spectator::IdPtr& id) { return registry_->GetMaxGauge(tagger_.GetId(id)); }
+  auto GetMonotonicCounter(std::string_view name, spectator::Tags tags = {}) {
+    return registry_->GetMonotonicCounter(tagger_.GetId(name, std::move(tags)));
+  }
+  auto GetMonotonicCounter(const spectator::IdPtr& id) {
+    return registry_->GetMonotonicCounter(tagger_.GetId(id));
+  }
+  auto GetTimer(std::string_view name, spectator::Tags tags = {}) {
+    return registry_->GetTimer(tagger_.GetId(name, std::move(tags)));
+  }
+  auto GetTimer(const spectator::IdPtr& id) { return registry_->GetTimer(tagger_.GetId(id)); }
+  auto GetPercentileTimer(const spectator::IdPtr& id, absl::Duration min, absl::Duration max) {
+    return registry_->GetPercentileTimer(id, min, max);
+  }
+
+  // types
+  using counter_t = typename Reg::counter_t;
+  using counter_ptr = std::shared_ptr<counter_t>;
+  using monotonic_counter_t = typename Reg::monotonic_counter_t;
+  using monotonic_counter_ptr = std::shared_ptr<monotonic_counter_t>;
+  using gauge_t = typename Reg::gauge_t;
+  using gauge_ptr = std::shared_ptr<gauge_t>;
+  using max_gauge_t = typename Reg::max_gauge_t;
+  using max_gauge_ptr = std::shared_ptr<max_gauge_t>;
+  using dist_summary_t = typename Reg::dist_summary_t;
+  using dist_summary_ptr = std::shared_ptr<dist_summary_t>;
+  using timer_t = typename Reg::timer_t;
+  using timer_ptr = std::shared_ptr<timer_t>;
+
+ private:
+  Reg* registry_;
+  Tagger tagger_;
+};
+
+using TaggingRegistry = base_tagging_registry<spectator::Registry>;
+}  // namespace atlasagent

--- a/lib/tagging_registry_test.cc
+++ b/lib/tagging_registry_test.cc
@@ -1,0 +1,94 @@
+#include "tagging_registry.h"
+#include "measurement_utils.h"
+#include <gtest/gtest.h>
+
+namespace {
+
+using Reg = atlasagent::base_tagging_registry<spectator::TestRegistry>;
+using atlasagent::Tagger;
+
+TEST(TaggingRegistry, Counter) {
+  Tagger::Rule rule{atlasagent::TagRuleOp::Name, "foo", {{"id", "val1"}}};
+  Tagger tagger{{rule}};
+  spectator::TestRegistry registry;
+  Reg reg{&registry, std::move(tagger)};
+
+  reg.GetCounter("ctr")->Increment();
+  reg.GetCounter("foo")->Increment();
+  reg.GetCounter(spectator::Id::of("foo", {{"key", "val2"}}))->Increment();
+  auto ms = my_measurements(&registry);
+  auto map = measurements_to_map(ms, "key");
+  expect_value(&map, "ctr|count", 1.0);
+  expect_value(&map, "foo|count|val1", 1.0);       // adds id=val1
+  expect_value(&map, "foo|count|val1|val2", 1.0);  // preserves prev tag
+  EXPECT_TRUE(map.empty());
+}
+
+TEST(TaggingRegistry, Gauge) {
+  Tagger::Rule rule{atlasagent::TagRuleOp::Name, "foo", {{"id", "val1"}}};
+  Tagger tagger{{rule}};
+  spectator::TestRegistry registry;
+  Reg reg{&registry, std::move(tagger)};
+
+  reg.GetGauge("g")->Set(1);
+  reg.GetGauge("foo")->Set(2);
+  reg.GetGauge(spectator::Id::of("foo", {{"key", "val2"}}))->Set(3);
+  auto ms = my_measurements(&registry);
+  auto map = measurements_to_map(ms, "key");
+  expect_value(&map, "g|gauge", 1.0);
+  expect_value(&map, "foo|gauge|val1", 2.0);       // adds id=val1
+  expect_value(&map, "foo|gauge|val1|val2", 3.0);  // preserves prev tag
+  EXPECT_TRUE(map.empty());
+}
+
+TEST(TaggingRegistry, MaxGauge) {
+  Tagger::Rule rule{atlasagent::TagRuleOp::Name, "foo", {{"id", "val1"}}};
+  Tagger tagger{{rule}};
+  spectator::TestRegistry registry;
+  Reg reg{&registry, std::move(tagger)};
+
+  reg.GetMaxGauge("g")->Set(1);
+  reg.GetMaxGauge("foo")->Set(2);
+  reg.GetMaxGauge(spectator::Id::of("foo", {{"key", "val2"}}))->Set(3);
+  auto ms = my_measurements(&registry);
+  auto map = measurements_to_map(ms, "key");
+  expect_value(&map, "g|max", 1.0);
+  expect_value(&map, "foo|max|val1", 2.0);       // adds id=val1
+  expect_value(&map, "foo|max|val1|val2", 3.0);  // preserves prev tag
+  EXPECT_TRUE(map.empty());
+}
+
+template <typename T>
+void expect_ids(T no_tags, T one, T two) {
+  auto empty = no_tags->MeterId()->GetTags();
+  EXPECT_EQ(empty.size(), 0);
+  auto one_tag = one->MeterId()->GetTags();
+  EXPECT_EQ(one_tag.size(), 1);
+  EXPECT_EQ(one_tag.at("id"), "val1");
+
+  auto two_tags = two->MeterId()->GetTags();
+  EXPECT_EQ(two_tags.size(), 2);
+  EXPECT_EQ(two_tags.at("id"), "val1");
+  EXPECT_EQ(two_tags.at("key"), "val2");
+}
+
+auto get_registry(spectator::TestRegistry* registry) {
+  Tagger::Rule rule{atlasagent::TagRuleOp::Name, "foo", {{"id", "val1"}}};
+  Tagger tagger{{rule}};
+  return Reg{registry, std::move(tagger)};
+}
+
+TEST(TaggingRegistry, DistSummary) {
+  spectator::TestRegistry registry;
+  Reg reg = get_registry(&registry);
+  expect_ids(reg.GetDistributionSummary("ds"), reg.GetDistributionSummary("foo"),
+             reg.GetDistributionSummary(spectator::Id::of("foo", {{"key", "val2"}})));
+}
+
+TEST(TaggingRegistry, Timer) {
+  spectator::TestRegistry registry;
+  Reg reg = get_registry(&registry);
+  expect_ids(reg.GetTimer("foo2"), reg.GetTimer("foo"),
+             reg.GetTimer(spectator::Id::of("foo", {{"key", "val2"}})));
+}
+}  // namespace

--- a/testdata/resources/atlas-agent.json
+++ b/testdata/resources/atlas-agent.json
@@ -1,0 +1,18 @@
+{
+  "tag_rules": [
+    {
+      "prefix": "disk.io.",
+      "tags": {
+        "tag-key1": "tag-val1",
+        "tag-key2": "tag-val2"
+      }
+    },
+    {
+      "name": "net.iface.bytes",
+      "tags": {
+        "tag-key1": "tag-val1",
+        "tag-key2": "tag-val2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This can be used by infrastructure teams that are interested in
subscribing to certain system level metrics.

The configuration is done throw a JSON configuration file which includes
a key `"tag_rules"`. This contains an array of rules that specify when
to add custom tags, and the tags to add. The rule can be either an exact
name match (`"name": "net.iface.bytes"`) or a specify they need to start
with a certain prefix. (`"prefix": "sys.load"`). For example:

```
{
  "tag_rules": [
    {
      "prefix": "disk.io.",
      "tags": {
        "tag-key1": "tag-val1",
        "tag-key2": "tag-val2"
      }
    },
    {
      "name": "net.iface.bytes",
      "tags": {
        "tag-key1": "tag-val1",
        "tag-key2": "tag-val2"
      }
    }
  ]
}
```