### PR TITLE
statically link binutils

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -79,7 +79,7 @@ cc_test(
     local_defines = select({
         "@bazel_tools//src/conditions:linux_x86_64": ["BACKWARD_HAS_BFD=1"],
         "//conditions:default": [],
-        }),
+    }),
     data = glob(["testdata/**"]),
     defines = select({
         ":titusagent": ["TITUS_AGENT=on"],
@@ -91,9 +91,12 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
     linkopts = select({
-                "@bazel_tools//src/conditions:linux_x86_64": ["-lbfd"],
-                "//conditions:default": [],
-            }),
+        "@bazel_tools//src/conditions:linux_x86_64": [
+            "/usr/lib/x86_64-linux-gnu/libbfd.a",
+            "/usr/lib/x86_64-linux-gnu/libiberty.a",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_binary(
@@ -106,11 +109,18 @@ cc_binary(
     local_defines = select({
         "@bazel_tools//src/conditions:linux_x86_64": ["BACKWARD_HAS_BFD=1"],
         "//conditions:default": [],
-        }),
+    }),
     includes = ["lib"],
-    deps = [":sysagent", "@com_github_bombela_backward//:backward"],
+    deps = [
+        ":sysagent",
+        "@com_github_bombela_backward//:backward"
+    ],
     linkopts = select({
-            "@bazel_tools//src/conditions:linux_x86_64": ["-lbfd"],
-            "//conditions:default": [],
-        }),
+        "@bazel_tools//src/conditions:linux_x86_64": [
+            "/usr/lib/x86_64-linux-gnu/libbfd.a",
+            "/usr/lib/x86_64-linux-gnu/libiberty.a",
+            "/usr/lib/x86_64-linux-gnu/libz.a",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,9 @@ fi
 
 # recommend 8GB RAM allocation for docker desktop, to allow the test build with asan to succeed
 cat >start-build <<EOF
+export CC="gcc-10"
+export CXX="g++-10"
+
 echo "-- build tests with address sanitizer enabled"
 bazel --output_user_root=$CACHE build --config=asan sysagent_test $ATLAS_TITUS_AGENT
 


### PR DESCRIPTION
The binutils library is included primarily for the purpose of producing
readable stack traces. With dynamic compilation, there was an issue
running the binary against multiple versions of Ubuntu. By switching to
static compilation and building on the oldest target Ubuntu version, we
can produce a binary that will work on all of the versions we support.

Also, use g++-10 in the local development build.