### PR TITLE
Add TCP memory metric

### DIFF
--- a/bin/atlas-agent.cc
+++ b/bin/atlas-agent.cc
@@ -49,15 +49,16 @@ std::unique_ptr<GpuMetrics> init_gpu(TaggingRegistry* registry, std::unique_ptr<
 #if defined(TITUS_AGENT) || defined(TITUS_SYSTEM_SERVICE)
 static void gather_titus_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aws* aws) {
   Logger()->info("Gathering titus metrics");
+  aws->update_stats();
   cGroup->cpu_stats();
   cGroup->memory_stats();
   cGroup->network_stats();
   disk->titus_disk_stats();
-  proc->network_stats();
-  proc->snmp_stats();
   proc->netstat_stats();
+  proc->network_stats();
   proc->process_stats();
-  aws->update_stats();
+  proc->socket_stats();
+  proc->snmp_stats();
 }
 #else
 static void gather_peak_system_metrics(Proc* proc) { proc->peak_cpu_stats(); }
@@ -66,18 +67,19 @@ static void gather_scaling_metrics(CpuFreq* cpufreq) { cpufreq->Stats(); }
 
 static void gather_slow_system_metrics(Proc* proc, Disk* disk, Ntp* ntp, Aws* aws) {
   Logger()->info("Gathering system metrics");
-  proc->cpu_stats();
-  proc->network_stats();
-  proc->arp_stats();
-  proc->snmp_stats();
-  proc->netstat_stats();
-  proc->loadavg_stats();
-  proc->memory_stats();
-  proc->vmstats();
-  proc->process_stats();
+  aws->update_stats();
   disk->disk_stats();
   ntp->update_stats();
-  aws->update_stats();
+  proc->arp_stats();
+  proc->cpu_stats();
+  proc->loadavg_stats();
+  proc->memory_stats();
+  proc->netstat_stats();
+  proc->network_stats();
+  proc->process_stats();
+  proc->snmp_stats();
+  proc->socket_stats();
+  proc->vmstats();
 }
 #endif
 

--- a/lib/internal/proc.inc
+++ b/lib/internal/proc.inc
@@ -756,6 +756,33 @@ inline int64_t to_int64(const std::string& s) {
 }
 
 template <typename Reg>
+void Proc<Reg>::socket_stats() noexcept {
+  auto pagesize = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  static auto tcp_memory = registry_->GetGauge("net.tcp.memory");
+
+  auto fp = open_file(path_prefix_, "net/sockstat");
+  if (fp == nullptr) {
+    return;
+  }
+
+  char line[1024];
+  while (fgets(line, sizeof line, fp) != nullptr) {
+    if (starts_with(line, "TCP:")) {
+      std::vector<std::string> values =
+          absl::StrSplit(line, absl::ByAnyChar(" \t\n"), absl::SkipEmpty());
+      auto idx = 0u;
+      for (const auto& value : values) {
+        if (value == "mem") {
+          tcp_memory->Set(to_int64(values[idx+1]) * pagesize);
+        }
+        ++idx;
+      }
+      break;
+    }
+  }
+}
+
+template <typename Reg>
 void Proc<Reg>::netstat_stats() noexcept {
   static auto ect_ctr = registry_->GetMonotonicCounter(
       create_id("net.ip.ectPackets", {{"id", "capable"}, {"proto", "v4"}}, net_tags_));

--- a/lib/proc.h
+++ b/lib/proc.h
@@ -17,6 +17,7 @@ class Proc {
   void peak_cpu_stats() noexcept;
   void memory_stats() noexcept;
   void process_stats() noexcept;
+  void socket_stats() noexcept;
   void vmstats() noexcept;
   [[nodiscard]] bool is_container() const noexcept;
 

--- a/lib/proc_test.cc
+++ b/lib/proc_test.cc
@@ -237,6 +237,19 @@ TEST(Proc, ParseNetstat) {
   EXPECT_TRUE(values.empty());
 }
 
+TEST(Proc, ParseSocketStats) {
+  Registry registry;
+  spectator::Tags extra{{"nf.test", "extra"}};
+  Proc proc{&registry, extra, "testdata/resources/proc"};
+  proc.socket_stats();
+
+  auto ms = my_measurements(&registry);
+  auto ms_map = measurements_to_map(ms, "proto");
+  auto pagesize = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  expect_value(&ms_map, "net.tcp.memory|gauge", 4519.0 * pagesize);
+  EXPECT_TRUE(ms_map.empty());
+}
+
 TEST(Proc, ArpStats) {
   Registry registry;
   spectator::Tags extra{{"nf.test", "extra"}};

--- a/testdata/resources/proc/net/sockstat
+++ b/testdata/resources/proc/net/sockstat
@@ -1,0 +1,6 @@
+sockets: used 8866
+TCP: inuse 8622 orphan 2 tw 32 alloc 8630 mem 4519
+UDP: inuse 3 mem 2
+UDPLITE: inuse 0
+RAW: inuse 0
+FRAG: inuse 0 memory 0


### PR DESCRIPTION
In order to be able to track TCP memory usage, we are adding one metric, which
is parsed from `/proc/net/sockstat`:

* net.tcp.memory - Number of bytes allocated to TCP memory.

This metric is a gauge, which will be collected once per minute, with common
tags applied. No additional tags are provided.

The corresponding `/proc/net/sockstat6` does not appear to have any information
on on memory and it looks like it is only used to track the number of `inuse`
sockets for IPv6.