### PR TITLE
remove socket stats metrics from titus agent

### DIFF
--- a/bin/atlas-agent.cc
+++ b/bin/atlas-agent.cc
@@ -57,7 +57,6 @@ static void gather_titus_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aws* aw
   proc->netstat_stats();
   proc->network_stats();
   proc->process_stats();
-  proc->socket_stats();
   proc->snmp_stats();
 }
 #else


### PR DESCRIPTION
These read directly from /proc, so they reflect the host values and
not the container values. Need to think more about this metric for
titus.