### PR TITLE
update nvidia library name

### DIFF
--- a/lib/config.h
+++ b/lib/config.h
@@ -8,7 +8,7 @@ static constexpr const char* kNvidiaLib =
 
 #elif defined(__linux__)
 
-    "libnvidia-ml.so";
+    "libnvidia-ml.so.1";
 
 #else
 


### PR DESCRIPTION
When the atlas-titus-agent used to be injected, it explicitly loaded the nvidia
libraries before doing the nsenter - that way, it could use the libraries on
the host. By moving into the container, we broke that behaviour, because while
the nvidia oci hook mounts those libraries, it doesn't make the symlink from
`.so.1` -> `.so`.

Rather than installing the nvidia dev package for all running containers, it
makes more sense to update the library name used by the agent. The existing
environment variable override for this value will remain in place, in case
there is a need to fast-fix environments in the event that the library name
changes again.