### PR TITLE
improve exclusion of loopback and ram disk devices

### DIFF
--- a/lib/disk_test.cc
+++ b/lib/disk_test.cc
@@ -48,7 +48,7 @@ TEST(Disk, MountPoints) {
   Registry registry;
   TestDisk disk(&registry);
   auto mount_points = disk.get_mount_points();
-  EXPECT_EQ(mount_points.size(), 7);
+  EXPECT_EQ(mount_points.size(), 16);
 
   disk.set_prefix("testdata/resources2");
   mount_points = disk.get_mount_points();
@@ -56,6 +56,7 @@ TEST(Disk, MountPoints) {
     Logger()->info("{}", mp);
   }
 }
+
 
 TEST(Disk, id) {
   using atlasagent::get_id_from_mountpoint;

--- a/lib/internal/disk.inc
+++ b/lib/internal/disk.inc
@@ -87,6 +87,9 @@ std::vector<MountPoint> Disk<Reg>::get_mount_points() const noexcept {
   return res;
 }
 
+static constexpr int kLoopDevice = 7;
+static constexpr int kRamDevice = 1;
+
 template <typename Reg>
 std::vector<MountPoint> Disk<Reg>::filter_interesting_mount_points(
     const std::vector<MountPoint>& mount_points) const noexcept {
@@ -94,6 +97,10 @@ std::vector<MountPoint> Disk<Reg>::filter_interesting_mount_points(
   std::unordered_map<uint64_t, const MountPoint*> candidates;
 
   for (const auto& mp : mount_points) {
+    if (mp.device_major == kLoopDevice || mp.device_major == kRamDevice) {
+      continue;
+    }
+
     if (starts_with(mp.mount_point.c_str(), "/sys") ||
         starts_with(mp.mount_point.c_str(), "/run") ||
         starts_with(mp.mount_point.c_str(), "/proc") ||
@@ -206,8 +213,6 @@ inline IdPtr id_for(const char* name, const char* id, const std::string& dev) {
   return spectator::Id::of(name, {{"id", id}, {"dev", dev.c_str()}});
 }
 
-static constexpr int kLoopDevice = 7;
-static constexpr int kRamDevice = 1;
 static constexpr const char* kRead = "read";
 static constexpr const char* kWrite = "write";
 

--- a/testdata/resources/proc/self/mountinfo
+++ b/testdata/resources/proc/self/mountinfo
@@ -32,3 +32,13 @@
 97 25 202:0 /tmp /tmp rw,nosuid,nodev,noatime - ext4 /dev/xvda rw,nobarrier,stripe=32582,data=ordered
 99 25 202:0 /var/tmp /var/tmp rw,nosuid,nodev,noexec,noatime - ext4 /dev/xvda rw,nobarrier,stripe=32582,data=ordered
 101 23 0:40 / /run/user/0 rw,nosuid,nodev,noexec,relatime shared:76 - tmpfs tmpfs rw,size=3294612k,mode=700
+750 24 7:0 / /snap/core/10185 ro,nodev,relatime shared:412 - squashfs /dev/loop0 ro
+767 24 7:1 / /snap/core18/1885 ro,nodev,relatime shared:421 - squashfs /dev/loop1 ro
+784 24 7:2 / /snap/lxd/16922 ro,nodev,relatime shared:430 - squashfs /dev/loop2 ro
+801 31 0:26 /snapd/ns /run/snapd/ns rw,nosuid,nodev - tmpfs tmpfs rw,size=3240304k,mode=755,inode64
+824 24 7:3 / /snap/amazon-ssm-agent/2012 ro,nodev,relatime shared:447 - squashfs /dev/loop3 ro
+494 24 7:4 / /snap/core18/2246 ro,nodev,relatime shared:273 - squashfs /dev/loop4 ro
+511 24 7:5 / /snap/core/11993 ro,nodev,relatime shared:281 - squashfs /dev/loop5 ro
+528 24 7:6 / /snap/core20/1242 ro,nodev,relatime shared:289 - squashfs /dev/loop6 ro
+545 24 7:7 / /snap/amazon-ssm-agent/4046 ro,nodev,relatime shared:297 - squashfs /dev/loop7 ro
+562 24 7:8 / /snap/lxd/21835 ro,nodev,relatime shared:305 - squashfs /dev/loop8 ro

--- a/testdata/resources2/proc/self/mountinfo
+++ b/testdata/resources2/proc/self/mountinfo
@@ -32,3 +32,13 @@
 97 25 202:0 /tmp /tmp rw,nosuid,nodev,noatime - ext4 /dev/xvda rw,nobarrier,stripe=32582,data=ordered
 99 25 202:0 /var/tmp /var/tmp rw,nosuid,nodev,noexec,noatime - ext4 /dev/xvda rw,nobarrier,stripe=32582,data=ordered
 101 23 0:40 / /run/user/0 rw,nosuid,nodev,noexec,relatime shared:76 - tmpfs tmpfs rw,size=3294612k,mode=700
+750 24 7:0 / /snap/core/10185 ro,nodev,relatime shared:412 - squashfs /dev/loop0 ro
+767 24 7:1 / /snap/core18/1885 ro,nodev,relatime shared:421 - squashfs /dev/loop1 ro
+784 24 7:2 / /snap/lxd/16922 ro,nodev,relatime shared:430 - squashfs /dev/loop2 ro
+801 31 0:26 /snapd/ns /run/snapd/ns rw,nosuid,nodev - tmpfs tmpfs rw,size=3240304k,mode=755,inode64
+824 24 7:3 / /snap/amazon-ssm-agent/2012 ro,nodev,relatime shared:447 - squashfs /dev/loop3 ro
+494 24 7:4 / /snap/core18/2246 ro,nodev,relatime shared:273 - squashfs /dev/loop4 ro
+511 24 7:5 / /snap/core/11993 ro,nodev,relatime shared:281 - squashfs /dev/loop5 ro
+528 24 7:6 / /snap/core20/1242 ro,nodev,relatime shared:289 - squashfs /dev/loop6 ro
+545 24 7:7 / /snap/amazon-ssm-agent/4046 ro,nodev,relatime shared:297 - squashfs /dev/loop7 ro
+562 24 7:8 / /snap/lxd/21835 ro,nodev,relatime shared:305 - squashfs /dev/loop8 ro


### PR DESCRIPTION
The BaseOS recently changed to move the loopback devices to a different
mount point, which caused them to bypass the existing filtering for the
disk.bytesUsed metrics.

This change uses the device major number as the filter filter pass to
ensure that these devices do not show up in the usage metrics.