### PR TITLE
fix stack overflow error when there are >= 1024 environment variables

### DIFF
--- a/contain/contain.c
+++ b/contain/contain.c
@@ -242,7 +242,7 @@ bool maybe_reexec(char* const* argv) {
 	snprintf(user_uid_env, sizeof(user_uid_env), "USER_UID=%d", st.st_uid);
 	snprintf(user_gid_env, sizeof(user_gid_env), "USER_GID=%d", st.st_gid);
 
-	/* 2. Make it into an ENVP */
+	/* 2. Make it into an ENVP, saving space for four additional values */
 	memset(envp, 0, sizeof(envp));
 	i = 0;
 	do {
@@ -251,7 +251,10 @@ bool maybe_reexec(char* const* argv) {
 			offset += strlen(&env[offset]) + 1;
 		} else
 			offset++;
-	} while (offset < env_length && i < ARRAY_SIZE(envp) - 1);
+	} while (offset < env_length && i < (ARRAY_SIZE(envp) - 5));
+
+	if (i >= (ARRAY_SIZE(envp) - 5))
+		fprintf(stderr, "Not capturing all environment variables.\n");
 
 	envp[i++] = LD_LIBRARY_PATH;
 	envp[i++] = LD_BIND_NOW1;


### PR DESCRIPTION
Note that the code path which calls `maybe_reexec` is not active and
has not been for some time, but since we are keeping the code around,
we will patch it to ensure that it does not cause issues in the future.