### PR TITLE
add ena driver metrics

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(sysagent
     "config.h"
     "cpufreq.h"
     "disk.h"
+    "ethtool.h"
     "files.h"
     "gpumetrics.h"
     "http_client.h"

--- a/lib/ethtool.h
+++ b/lib/ethtool.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "absl/strings/str_split.h"
+#include "tagging_registry.h"
+#include "util.h"
+
+namespace atlasagent {
+
+using spectator::Id;
+using spectator::IdPtr;
+using spectator::Tags;
+
+template <typename Reg = TaggingRegistry>
+class Ethtool {
+ public:
+  explicit Ethtool(Reg* registry, Tags net_tags) noexcept
+      : registry_(registry),
+        net_tags_{std::move(net_tags)} {}
+
+  void update_stats() noexcept {
+    if (can_execute("ethtool")) {
+      if (interfaces_.empty()) {
+        auto ip_links = read_output_lines("ip link show");
+        interfaces_ = enumerate_interfaces(ip_links);
+      }
+
+      for (auto iface : interfaces_) {
+        auto nic_stats = read_output_lines(fmt::format("ethtool -S {}", iface).c_str());
+        ethtool_stats(nic_stats, iface.c_str());
+      }
+    }
+  }
+
+ private:
+  Reg* registry_;
+  const spectator::Tags net_tags_;
+  std::vector<std::string> interfaces_;
+
+ protected:
+  std::vector<std::string> enumerate_interfaces(const std::vector<std::string>& lines) {
+    std::vector<std::string> result;
+    std::size_t found;
+    for (const auto& line : lines) {
+      if (line[0] == ' ') {
+        continue;
+      }
+      found = line.find("eth");
+      if (found != std::string::npos) {
+        std::vector<std::string> fields = absl::StrSplit(line, ' ');
+        auto iface = fields[1].substr(0, fields[1].size() - 1);
+        result.emplace_back(iface);
+      }
+    }
+    return result;
+  }
+
+  void update_metric(const std::string& stat_line, typename Reg::monotonic_counter_ptr metric) {
+    std::vector<std::string> stat_fields = absl::StrSplit(stat_line, ':');
+    try {
+      auto number = std::stoll(stat_fields[1]);
+      metric->Set(number);
+    } catch (const std::invalid_argument& e) {
+      atlasagent::Logger()->error("Unable to parse {} as a number: {}", stat_fields[1], e.what());
+    }
+  }
+
+  void ethtool_stats(const std::vector<std::string>& nic_stats, const char* iface) noexcept {
+    std::size_t found;
+
+    for (const auto& stat_line : nic_stats) {
+      found = stat_line.find("bw_in_allowance_exceeded:");
+      if (found != std::string::npos) {
+        auto metric = registry_->GetMonotonicCounter(id_for("net.perf.bwAllowanceExceeded", iface, "in", net_tags_));
+        update_metric(stat_line, metric);
+        continue;
+      }
+
+      found = stat_line.find("bw_out_allowance_exceeded:");
+      if (found != std::string::npos) {
+        auto metric = registry_->GetMonotonicCounter(id_for("net.perf.bwAllowanceExceeded", iface, "out", net_tags_));
+        update_metric(stat_line, metric);
+        continue;
+      }
+
+      found = stat_line.find("conntrack_allowance_exceeded:");
+      if (found != std::string::npos) {
+        auto metric = registry_->GetMonotonicCounter(id_for("net.perf.conntrackAllowanceExceeded", iface, nullptr, net_tags_));
+        update_metric(stat_line, metric);
+        continue;
+      }
+
+      found = stat_line.find("linklocal_allowance_exceeded:");
+      if (found != std::string::npos) {
+        auto metric = registry_->GetMonotonicCounter(id_for("net.perf.linklocalAllowanceExceeded", iface, nullptr, net_tags_));
+        update_metric(stat_line, metric);
+        continue;
+      }
+
+      found = stat_line.find("pps_allowance_exceeded:");
+      if (found != std::string::npos) {
+        auto metric = registry_->GetMonotonicCounter(id_for("net.perf.ppsAllowanceExceeded", iface, nullptr, net_tags_));
+        update_metric(stat_line, metric);
+      }
+    }
+  }
+};
+}  // namespace atlasagent

--- a/lib/ethtool_test.cc
+++ b/lib/ethtool_test.cc
@@ -1,0 +1,105 @@
+#include "logger.h"
+#include "measurement_utils.h"
+#include "ethtool.h"
+#include <gtest/gtest.h>
+
+namespace {
+
+using atlasagent::Logger;
+using atlasagent::Ethtool;
+using Registry = spectator::TestRegistry;
+using spectator::Tags;
+
+class CT : public Ethtool<Registry> {
+ public:
+  explicit CT(Registry* registry) : Ethtool{registry, Tags{}} {}
+
+  void stats(const std::vector<std::string>& nic_stats, const char* iface) noexcept {
+    Ethtool::ethtool_stats(nic_stats, iface);
+  }
+
+  std::vector<std::string> ifaces(const std::vector<std::string>& ip_links) {
+    return Ethtool::enumerate_interfaces(ip_links);
+  }
+};
+
+TEST(Ethtool, Stats) {
+  Registry registry;
+  CT ethtool{&registry};
+
+  std::vector<std::string> first_sample = {
+      "NIC statistics:\n",
+      "    suspend: 0\n",
+      "    resume: 0\n",
+      "    bw_in_allowance_exceeded: 0\n",
+      "    bw_out_allowance_exceeded: 0\n",
+      "    pps_allowance_exceeded: 0\n",
+      "    conntrack_allowance_exceeded: 0\n",
+      "    linklocal_allowance_exceeded: 0\n",
+      "    queue_0_tx_cnt: 368940\n",
+      "    queue_0_tx_bytes: 126196057\n"};
+
+  ethtool.stats(first_sample, "eth0");
+  auto ms = registry.Measurements();
+  EXPECT_EQ(ms.size(), 0);
+
+  std::vector<std::string> second_sample = {
+      "NIC statistics:\n",
+      "    suspend: 0\n",
+      "    resume: 0\n",
+      "    bw_in_allowance_exceeded: 5\n",
+      "    bw_out_allowance_exceeded: 10\n",
+      "    conntrack_allowance_exceeded: 15\n",
+      "    linklocal_allowance_exceeded: 20\n",
+      "    pps_allowance_exceeded: 25\n",
+      "    queue_0_tx_cnt: 368940\n",
+      "    queue_0_tx_bytes: 126196057\n"};
+
+  // we need two samples, because these are all monotonic counters
+  ethtool.stats(second_sample, "eth0");
+  ms = registry.Measurements();
+  EXPECT_EQ(ms.size(), 5);
+
+  auto map = measurements_to_map(ms, "");
+  std::unordered_map<std::string, double> expected = {
+      {"net.perf.bwAllowanceExceeded|count|in", 5},
+      {"net.perf.bwAllowanceExceeded|count|out", 10},
+      {"net.perf.conntrackAllowanceExceeded|count", 15},
+      {"net.perf.linklocalAllowanceExceeded|count", 20},
+      {"net.perf.ppsAllowanceExceeded|count", 25}};
+  EXPECT_EQ(map, expected);
+}
+
+TEST(Ethtool, StatsEmpty) {
+  Registry registry;
+  CT ethtool{&registry};
+
+  ethtool.stats({}, "");
+  auto ms = registry.Measurements();
+  EXPECT_EQ(ms.size(), 0);
+
+  ethtool.stats({}, "");
+  ms = registry.Measurements();
+  EXPECT_EQ(ms.size(), 0);
+}
+
+TEST(Ethtool, EnumerateInterfaces) {
+  Registry registry;
+  CT ethtool{&registry};
+
+  std::vector<std::string> ip_links = {
+      "1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000\n",
+      "   link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00\n",
+      "2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP mode DEFAULT group default qlen 1000\n",
+      "   link/ether 0a:69:fb:fa:96:77 brd ff:ff:ff:ff:ff:ff\n",
+      "   altname enp0s5\n",
+      "   altname ens5\n",
+      "3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP mode DEFAULT group default qlen 1000\n",
+      "   link/ether 0a:69:fb:fa:96:78 brd ff:ff:ff:ff:ff:ff\n",
+      "   altname enp0s6\n",
+      "   altname ens6\n"};
+
+  std::vector<std::string> expected{"eth0", "eth1"};
+  EXPECT_EQ(ethtool.ifaces(ip_links), expected);
+}
+}  // namespace

--- a/lib/internal/proc.inc
+++ b/lib/internal/proc.inc
@@ -16,16 +16,6 @@ using spectator::Id;
 using spectator::IdPtr;
 using spectator::Tags;
 
-inline IdPtr id_for(const char* name, const char* iface, const char* idStr,
-                    const spectator::Tags& extra) noexcept {
-  Tags tags{extra};
-  tags.add("iface", iface);
-  if (idStr != nullptr) {
-    tags.add("id", idStr);
-  }
-  return Id::of(name, tags);
-}
-
 template <typename Reg>
 void Proc<Reg>::handle_line(FILE* fp) noexcept {
   char iface[4096];

--- a/lib/util.h
+++ b/lib/util.h
@@ -32,4 +32,15 @@ bool can_execute(const std::string& program);
 // parse a string of the form key=val,key2=val2 into spectator Tags
 spectator::Tags parse_tags(const char* s);
 
+// construct a spectator id with extra tags - intended for use with network interface metrics
+inline spectator::IdPtr id_for(const char* name, const char* iface, const char* idStr,
+                    const spectator::Tags& extra) noexcept {
+  spectator::Tags tags{extra};
+  tags.add("iface", iface);
+  if (idStr != nullptr) {
+    tags.add("id", idStr);
+  }
+  return spectator::Id::of(name, tags);
+}
+
 }  // namespace atlasagent


### PR DESCRIPTION
This change adds support for the following five Elastic Network Adapter
performance metrics, which are available on EC2 instances:

* bw_in_allowance_exceeded
* bw_out_allowance_exceeded
* conntrack_allowance_exceeded
* linklocal_allowance_exceeded
* pps_allowance_exceeded

There are a few apps in our environment which may hit conntrack limits, and
these metrics are a good means of detecting that state. All of these metrics
are configured as Monotonic Counters, since all of the statistics report the
cumulative number of packets queued or dropped on each network interface since
the last driver reset.

The first time that metrics collection occurs, the ethernet interfaces on the
instance will enumerated, so that these statistics may be collected for each
one.