### PR TITLE
exclude /mnt/docker mount points from disk metrics

### DIFF
--- a/lib/internal/disk.inc
+++ b/lib/internal/disk.inc
@@ -102,10 +102,11 @@ std::vector<MountPoint> Disk<Reg>::filter_interesting_mount_points(
       continue;
     }
 
-    if (starts_with(mp.mount_point.c_str(), "/sys") ||
-        starts_with(mp.mount_point.c_str(), "/run") ||
+    if (starts_with(mp.mount_point.c_str(), "/dev") ||
+        starts_with(mp.mount_point.c_str(), "/mnt/docker") ||
         starts_with(mp.mount_point.c_str(), "/proc") ||
-        starts_with(mp.mount_point.c_str(), "/dev")) {
+        starts_with(mp.mount_point.c_str(), "/run") ||
+        starts_with(mp.mount_point.c_str(), "/sys")) {
       continue;
     }
 


### PR DESCRIPTION
When this runs on Titus Agent hosts, there are a very large number of these metrics reporting (>9M), and we want to remove them. The containers themselves will continue to report disk metrics through their own agent process.