### PR TITLE
update build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/*.inc
 .DS_Store
 .idea/
-cmake-build-debug/
+cmake-build-debug
 cmake-build/
 lib/spectator/
 spectator-cpp-*.zip

--- a/README.md
+++ b/README.md
@@ -8,19 +8,22 @@ An agent that reports metrics for EC2 instances or [Titus] containers.
 
 ## Local Development
 
-Due to the nature of what this agent is, it does not compile cleanly on MacOS. It is best to build on a Linux
-machine:
+This agent was designed for Linux systems, and as a result, it does not compile cleanly on macOS. It
+is best to build on a Linux machine:
 
 ```shell
+# setup python venv and activate, to gain access to conan cli
 ./setup-venv.sh
 source venv/bin/activate
-./build.sh  # [clean|skiptest]
+
+# link clion default build directory to our build directory
+ln -s cmake-build cmake-build-debug
+
+./build.sh  # [clean|clean --force|skiptest]
 ```
 
-* CLion version 2022.1.3 required until the Conan plugin is updated
 * CLion > Preferences > Plugins > Marketplace > Conan > Install
 * CLion > Preferences > Build, Execution, Deploy > Conan > Conan Executable: $PROJECT_HOME/venv/bin/conan
-* CLion > Bottom Bar: Conan > Left Button: Match Profile > CMake Profile: Debug, Conan Profile: default
 
 ## Debugging
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# usage: ./build.sh [clean|clean --force|skiptest]
+
 BUILD_DIR=cmake-build
 # Choose: Debug, Release, RelWithDebInfo and MinSizeRel
 BUILD_TYPE=Debug
@@ -12,8 +14,10 @@ if [[ "$1" == "clean" ]]; then
   rm -rf $BUILD_DIR
   rm -f spectator-cpp-*.zip
   rm -rf lib/spectator
-  # remove all packages and binaries from the local cache, to allow swapping between Debug/Release builds
-  conan remove '*' --force
+  if [[ "$2" == "--force" ]]; then
+    # remove all packages and binaries from the local cache, to allow swapping between Debug/Release builds
+    conan remove '*' --force
+  fi
 fi
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then


### PR DESCRIPTION
The clean function of the build script was removing the conan binary cache far too often, resulting in slower builds. This should be a special action that is only done when switching between Debug and Release builds, where there is an impact on the use of the address sanitizer.