### PR TITLE
publish `TITUS_NUM_CPU` value as `titus.cpu.requested`

### DIFF
--- a/lib/cgroup_test.cc
+++ b/lib/cgroup_test.cc
@@ -47,6 +47,8 @@ TEST(CGroup, ParseCpuV1) {
   bool is_cgroup2{false};
 
   auto now = absl::Now();
+  // pick 1 here, so as not to disturb the existing cpu metrics
+  setenv("TITUS_NUM_CPU", "1", 1);
   cGroup.cpu_stats(now, is_cgroup2);
   cGroup.cpu_peak_stats(now, is_cgroup2);
   auto initial = my_measurements(&registry);
@@ -54,8 +56,7 @@ TEST(CGroup, ParseCpuV1) {
   expect_value(&initial_map, "cgroup.cpu.processingCapacity|count", 30.0);
   expect_value(&initial_map, "cgroup.cpu.shares|gauge", 1024);
   expect_value(&initial_map, "sys.cpu.numProcessors|gauge", 1);
-  EXPECT_EQ(initial_map.size(), 0);
-  EXPECT_TRUE(initial_map.empty());
+  EXPECT_EQ(initial_map.size(), 1);
 
   cGroup.set_prefix("testdata/resources2");
   cGroup.cpu_stats(now + absl::Seconds(5), is_cgroup2);
@@ -75,6 +76,7 @@ TEST(CGroup, ParseCpuV1) {
   expect_value(&map, "sys.cpu.peakUtilization|max|user", 20);
   expect_value(&map, "sys.cpu.utilization|gauge|system", 2.1999999999999997);
   expect_value(&map, "sys.cpu.utilization|gauge|user", 20);
+  expect_value(&map, "titus.cpu.requested|gauge", 1);
   EXPECT_TRUE(map.empty());
 }
 
@@ -84,6 +86,8 @@ TEST(CGroup, ParseCpuV2) {
   bool is_cgroup2{true};
 
   auto now = absl::Now();
+  // pick 1 here, so as not to disturb the existing cpu metrics
+  setenv("TITUS_NUM_CPU", "1", 1);
   cGroup.cpu_stats(now, is_cgroup2);
   cGroup.cpu_peak_stats(now, is_cgroup2);
   auto initial = my_measurements(&registry);
@@ -91,8 +95,7 @@ TEST(CGroup, ParseCpuV2) {
   expect_value(&initial_map, "cgroup.cpu.processingCapacity|count", 30.0);
   expect_value(&initial_map, "cgroup.cpu.weight|gauge", 100);
   expect_value(&initial_map, "sys.cpu.numProcessors|gauge", 1);
-  EXPECT_EQ(initial_map.size(), 0);
-  EXPECT_TRUE(initial_map.empty());
+  EXPECT_EQ(initial_map.size(), 1);
 
   cGroup.set_prefix("testdata/resources2");
   cGroup.cpu_stats(now + absl::Seconds(5), is_cgroup2);
@@ -112,6 +115,7 @@ TEST(CGroup, ParseCpuV2) {
   expect_value(&map, "sys.cpu.peakUtilization|max|user", 1200);
   expect_value(&map, "sys.cpu.utilization|gauge|system", 2400);
   expect_value(&map, "sys.cpu.utilization|gauge|user", 1200);
+  expect_value(&map, "titus.cpu.requested|gauge", 1);
   EXPECT_TRUE(map.empty());
 }
 

--- a/lib/internal/cgroup.inc
+++ b/lib/internal/cgroup.inc
@@ -34,6 +34,8 @@ void CGroup<Reg>::cpu_shares_v1(absl::Time now) noexcept {
     n = strtod(num_cpu, nullptr);
     if (n <= 0) {
       Logger()->info("Unable to fetch processing capacity from env var. [{}]", num_cpu);
+    } else {
+      registry_->GetGauge("titus.cpu.requested")->Set(n);
     }
   }
 
@@ -69,6 +71,8 @@ void CGroup<Reg>::cpu_shares_v2(absl::Time now) noexcept {
     n = strtod(num_cpu, nullptr);
     if (n <= 0) {
       Logger()->info("Unable to fetch processing capacity from env var. [{}]", num_cpu);
+    } else {
+      registry_->GetGauge("titus.cpu.requested")->Set(n);
     }
   }
 


### PR DESCRIPTION
Titus is moving away from setting the `cgroup.cpu.shares` value. The shares is
not the same as the number of cpus, although it is often incorrectly used that way.

It is not a good cgroup field to use for a metric, because it is something that
we optionally set, rather than something system-provided, as is the case for
every other cgroup metric. The `cgroup.cpu.processingCapacity` metric is better
in most cases, but some people want to know the requested cpu count.


This change reports the `TITUS_NUM_CPU` environment variable as the
`titus.cpus.requested` metric.