### PR TITLE
remove cgroupv1 collection methods

### DIFF
--- a/bin/atlas-agent.cc
+++ b/bin/atlas-agent.cc
@@ -84,9 +84,6 @@ static void gather_slow_titus_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aw
   if (is_cgroup2) {
     cGroup->memory_stats_v2();
     cGroup->memory_stats_std_v2();
-  } else {
-    cGroup->memory_stats_v1();
-    cGroup->memory_stats_std_v1();
   }
   cGroup->network_stats();
   disk->titus_disk_stats();

--- a/lib/cgroup.h
+++ b/lib/cgroup.h
@@ -15,9 +15,7 @@ class CGroup {
 
   void cpu_stats(bool is_cgroup2) noexcept { do_cpu_stats(absl::Now(), is_cgroup2); }
   void cpu_peak_stats(bool is_cgroup2) noexcept { do_cpu_peak_stats(absl::Now(), is_cgroup2); }
-  void memory_stats_v1() noexcept;
   void memory_stats_v2() noexcept;
-  void memory_stats_std_v1() noexcept;
   void memory_stats_std_v2() noexcept;
   void network_stats() noexcept;
   void pressure_stall() noexcept;
@@ -29,19 +27,12 @@ class CGroup {
   absl::Duration update_interval_;
   double user_hz_{sysconf(_SC_CLK_TCK) * 1.0};
 
-  void cpu_processing_time_v1() noexcept;
   void cpu_processing_time_v2() noexcept;
-  void cpu_shares_v1(absl::Time now) noexcept;
   void cpu_shares_v2(absl::Time now) noexcept;
-  void cpu_throttle_v1() noexcept;
   void cpu_throttle_v2() noexcept;
-  void cpu_usage_time_v1() noexcept;
   void cpu_usage_time_v2() noexcept;
-  void cpu_utilization_v1(absl::Time now) noexcept;
   void cpu_utilization_v2(absl::Time now) noexcept;
-  void cpu_peak_utilization_v1(absl::Time now) noexcept;
   void cpu_peak_utilization_v2(absl::Time now) noexcept;
-  void kmem_stats_v1() noexcept;
 
  protected:
   // for testing

--- a/lib/cgroup_test.cc
+++ b/lib/cgroup_test.cc
@@ -63,45 +63,6 @@ TEST(CGroup, PressureStall) {
   EXPECT_TRUE(map.empty());
 }
 
-TEST(CGroup, ParseCpuV1) {
-  Registry registry;
-  CGroupTest cGroup{&registry, "testdata/resources", absl::Seconds(30)};
-  bool is_cgroup2{false};
-
-  auto now = absl::Now();
-  // pick 1 here, so as not to disturb the existing cpu metrics
-  setenv("TITUS_NUM_CPU", "1", 1);
-  cGroup.cpu_stats(now, is_cgroup2);
-  cGroup.cpu_peak_stats(now, is_cgroup2);
-  auto initial = my_measurements(&registry);
-  auto initial_map = measurements_to_map(initial, "");
-  expect_value(&initial_map, "cgroup.cpu.processingCapacity|count", 30.0);
-  expect_value(&initial_map, "cgroup.cpu.shares|gauge", 1024);
-  expect_value(&initial_map, "sys.cpu.numProcessors|gauge", 1);
-  EXPECT_EQ(initial_map.size(), 1);
-
-  cGroup.set_prefix("testdata/resources2");
-  cGroup.cpu_stats(now + absl::Seconds(5), is_cgroup2);
-  cGroup.cpu_peak_stats(now + absl::Seconds(5), is_cgroup2);
-
-  const auto& ms = my_measurements(&registry);
-  measurement_map map = measurements_to_map(ms, "proto");
-  expect_value(&map, "cgroup.cpu.numThrottled|count", 2);
-  expect_value(&map, "cgroup.cpu.processingCapacity|count", 5.0);
-  expect_value(&map, "cgroup.cpu.processingTime|count", 30);
-  expect_value(&map, "cgroup.cpu.shares|gauge", 1024);
-  expect_value(&map, "cgroup.cpu.throttledTime|count", 1);
-  expect_value(&map, "cgroup.cpu.usageTime|count|system", 120);
-  expect_value(&map, "cgroup.cpu.usageTime|count|user", 60);
-  expect_value(&map, "sys.cpu.numProcessors|gauge", 1);
-  expect_value(&map, "sys.cpu.peakUtilization|max|system", 2.1999999999999997);
-  expect_value(&map, "sys.cpu.peakUtilization|max|user", 20);
-  expect_value(&map, "sys.cpu.utilization|gauge|system", 2.1999999999999997);
-  expect_value(&map, "sys.cpu.utilization|gauge|user", 20);
-  expect_value(&map, "titus.cpu.requested|gauge", 1);
-  EXPECT_TRUE(map.empty());
-}
-
 TEST(CGroup, ParseCpuV2) {
   Registry registry;
   CGroupTest cGroup{&registry, "testdata/resources", absl::Seconds(30)};
@@ -139,48 +100,6 @@ TEST(CGroup, ParseCpuV2) {
   expect_value(&map, "sys.cpu.utilization|gauge|user", 1200);
   expect_value(&map, "titus.cpu.requested|gauge", 1);
   EXPECT_TRUE(map.empty());
-}
-
-TEST(CGroup, ParseMemoryV1) {
-  Registry registry;
-  CGroupTest cGroup{&registry, "testdata/resources"};
-  bool is_cgroup2{false};
-
-  cGroup.memory_stats_v1();
-  cGroup.memory_stats_std_v1();
-  auto initial = my_measurements(&registry);
-  EXPECT_EQ(initial.size(), 20);
-
-  cGroup.set_prefix("testdata/resources2");
-  cGroup.memory_stats_v1();
-  cGroup.memory_stats_std_v1();
-  auto ms = my_measurements(&registry);
-  auto values = measurements_to_map(ms, "");
-  expect_value(&values, "cgroup.kmem.failures|count", 4);
-  expect_value(&values, "cgroup.kmem.limit|gauge", 9223372036854771712.0);
-  expect_value(&values, "cgroup.kmem.maxUsed|gauge", 14598144.0);
-  expect_value(&values, "cgroup.kmem.tcpLimit|gauge", 9223372036854771712.0);
-  expect_value(&values, "cgroup.kmem.tcpMaxUsed|gauge", 0);
-  expect_value(&values, "cgroup.kmem.tcpUsed|gauge", 0);
-  expect_value(&values, "cgroup.kmem.used|gauge", 14528144.0);
-  expect_value(&values, "cgroup.mem.failures|count", 2);
-  expect_value(&values, "cgroup.mem.limit|gauge", 8589934592);
-  expect_value(&values, "cgroup.mem.pageFaults|count|major", 10);
-  expect_value(&values, "cgroup.mem.pageFaults|count|minor", 1000);
-  expect_value(&values, "cgroup.mem.processUsage|gauge|cache", 11218944);
-  expect_value(&values, "cgroup.mem.processUsage|gauge|mapped_file", 3);
-  expect_value(&values, "cgroup.mem.processUsage|gauge|rss", 1);
-  expect_value(&values, "cgroup.mem.processUsage|gauge|rss_huge", 2);
-  expect_value(&values, "cgroup.mem.used|gauge", 7841374208);
-  expect_value(&values, "mem.availReal|gauge", 759779328);
-  expect_value(&values, "mem.availSwap|gauge", 8589934592);
-  expect_value(&values, "mem.cached|gauge", 11218944);
-  expect_value(&values, "mem.freeReal|gauge", 748560384);
-  expect_value(&values, "mem.shared|gauge", 135168);
-  expect_value(&values, "mem.totalFree|gauge", 9338249216);
-  expect_value(&values, "mem.totalReal|gauge", 8589934592);
-  expect_value(&values, "mem.totalSwap|gauge", 8589934592);
-  EXPECT_TRUE(values.empty());
 }
 
 TEST(CGroup, ParseMemoryV2) {

--- a/lib/internal/cgroup.inc
+++ b/lib/internal/cgroup.inc
@@ -62,43 +62,6 @@ void CGroup<Reg>::pressure_stall() noexcept {
 }
 
 template <typename Reg>
-void CGroup<Reg>::cpu_shares_v1(absl::Time now) noexcept {
-  static absl::Time last_updated;
-
-  auto shares = read_num_from_file(path_prefix_, "cpu/cpu.shares");
-  if (shares >= 0) {
-    registry_->GetGauge("cgroup.cpu.shares")->Set(shares);
-  }
-
-  // use an environment variable to set the processing capacity
-  auto num_cpu = std::getenv("TITUS_NUM_CPU");
-  auto n = 0.0;
-  if (num_cpu != nullptr) {
-    n = strtod(num_cpu, nullptr);
-    if (n <= 0) {
-      Logger()->info("Unable to fetch processing capacity from env var. [{}]", num_cpu);
-    } else {
-      registry_->GetGauge("titus.cpu.requested")->Set(n);
-    }
-  }
-
-  if (n <= 0) {
-    auto cfs_quota = read_num_from_file(path_prefix_, "cpuacct/cpu.cfs_quota_us");
-    auto cfs_period = read_num_from_file(path_prefix_, "cpuacct/cpu.cfs_period_us");
-    n = cfs_quota / cfs_period;
-  }
-
-  if (n > 0) {
-    if (last_updated == absl::UnixEpoch()) {
-      last_updated = now - update_interval_;
-    }
-    auto delta_t = absl::ToDoubleSeconds(now - last_updated);
-    last_updated = now;
-    registry_->GetCounter("cgroup.cpu.processingCapacity")->Add(delta_t * n);
-  }
-}
-
-template <typename Reg>
 void CGroup<Reg>::cpu_shares_v2(absl::Time now) noexcept {
   static absl::Time last_updated;
 
@@ -137,18 +100,6 @@ void CGroup<Reg>::cpu_shares_v2(absl::Time now) noexcept {
 }
 
 template <typename Reg>
-void CGroup<Reg>::cpu_processing_time_v1() noexcept {
-  auto time_nanos = read_num_from_file(path_prefix_, "cpuacct/cpuacct.usage");
-
-  static auto counter = registry_->GetCounter("cgroup.cpu.processingTime");
-  static int64_t prev = 0;
-  if (prev != 0) {
-    counter->Add((time_nanos - prev) / NANOS);
-  }
-  prev = time_nanos;
-}
-
-template <typename Reg>
 void CGroup<Reg>::cpu_processing_time_v2() noexcept {
   std::unordered_map<std::string, int64_t> stats;
   parse_kv_from_file(path_prefix_, "cpu.stat", &stats);
@@ -159,29 +110,6 @@ void CGroup<Reg>::cpu_processing_time_v2() noexcept {
     counter->Add((stats["usage_usec"] - prev) / MICROS);
   }
   prev = stats["usage_usec"];
-}
-
-template <typename Reg>
-void CGroup<Reg>::cpu_usage_time_v1() noexcept {
-  std::unordered_map<std::string, int64_t> stats;
-  // cpustat.acct values are reported in USER_HZ (usually, 100 per second)
-  parse_kv_from_file(path_prefix_, "cpuacct/cpuacct.stat", &stats);
-
-  static auto system_usage = registry_->GetCounter("cgroup.cpu.usageTime", {{"id", "system"}});
-  static auto prev_sys_usage = static_cast<int64_t>(-1);
-  if (prev_sys_usage >= 0) {
-    auto secs = (stats["system"] - prev_sys_usage) / user_hz_;
-    system_usage->Add(secs);
-  }
-  prev_sys_usage = stats["system"];
-
-  static auto user_usage = registry_->GetCounter("cgroup.cpu.usageTime", {{"id", "user"}});
-  static auto prev_user_usage = static_cast<int64_t>(-1);
-  if (prev_user_usage >= 0) {
-    auto secs = (stats["user"] - prev_user_usage) / user_hz_;
-    user_usage->Add(secs);
-  }
-  prev_user_usage = stats["user"];
 }
 
 template <typename Reg>
@@ -204,37 +132,6 @@ void CGroup<Reg>::cpu_usage_time_v2() noexcept {
     user_usage->Add(secs);
   }
   prev_user_usage = stats["user_usec"];
-}
-
-template <typename Reg>
-void CGroup<Reg>::cpu_utilization_v1(absl::Time now) noexcept {
-  static absl::Time last_updated;
-  auto delta_t = absl::ToDoubleSeconds(now - last_updated);
-  last_updated = now;
-
-  static auto num_procs = registry_->GetGauge("sys.cpu.numProcessors");
-  auto cfs_quota = read_num_from_file(path_prefix_, "cpuacct/cpu.cfs_quota_us");
-  auto cfs_period = read_num_from_file(path_prefix_, "cpuacct/cpu.cfs_period_us");
-  auto avail_cpu_time = (delta_t / cfs_period) * cfs_quota;
-  num_procs->Set(cfs_quota / cfs_period);
-
-  static auto cpu_system = registry_->GetGauge("sys.cpu.utilization", {{"id", "system"}});
-  static auto prev_system_time = static_cast<int64_t>(-1);
-  auto system_time = read_num_from_file(path_prefix_, "cpuacct/cpuacct.usage_sys");
-  if (prev_system_time >= 0) {
-    auto secs = (system_time - prev_system_time) / NANOS;
-    cpu_system->Set((secs / avail_cpu_time) * 100);
-  }
-  prev_system_time = system_time;
-
-  static auto cpu_user = registry_->GetGauge("sys.cpu.utilization", {{"id", "user"}});
-  static auto prev_user_time = static_cast<int64_t>(-1);
-  auto user_time = read_num_from_file(path_prefix_, "cpuacct/cpuacct.usage_user");
-  if (prev_user_time >= 0) {
-    auto secs = (user_time - prev_user_time) / NANOS;
-    cpu_user->Set((secs / avail_cpu_time) * 100);
-  }
-  prev_user_time = user_time;
 }
 
 template <typename Reg>
@@ -271,35 +168,6 @@ void CGroup<Reg>::cpu_utilization_v2(absl::Time now) noexcept {
 }
 
 template <typename Reg>
-void CGroup<Reg>::cpu_peak_utilization_v1(absl::Time now) noexcept {
-  static absl::Time last_updated;
-  auto delta_t = absl::ToDoubleSeconds(now - last_updated);
-  last_updated = now;
-
-  auto cfs_quota = read_num_from_file(path_prefix_, "cpuacct/cpu.cfs_quota_us");
-  auto cfs_period = read_num_from_file(path_prefix_, "cpuacct/cpu.cfs_period_us");
-  auto avail_cpu_time = (delta_t / cfs_period) * cfs_quota;
-
-  static auto cpu_system = registry_->GetMaxGauge("sys.cpu.peakUtilization", {{"id", "system"}});
-  static auto prev_system_time = static_cast<int64_t>(-1);
-  auto system_time = read_num_from_file(path_prefix_, "cpuacct/cpuacct.usage_sys");
-  if (prev_system_time >= 0) {
-    auto secs = (system_time - prev_system_time) / NANOS;
-    cpu_system->Set((secs / avail_cpu_time) * 100);
-  }
-  prev_system_time = system_time;
-
-  static auto cpu_user = registry_->GetMaxGauge("sys.cpu.peakUtilization", {{"id", "user"}});
-  static auto prev_user_time = static_cast<int64_t>(-1);
-  auto user_time = read_num_from_file(path_prefix_, "cpuacct/cpuacct.usage_user");
-  if (prev_user_time >= 0) {
-    auto secs = (user_time - prev_user_time) / NANOS;
-    cpu_user->Set((secs / avail_cpu_time) * 100);
-  }
-  prev_user_time = user_time;
-}
-
-template <typename Reg>
 void CGroup<Reg>::cpu_peak_utilization_v2(absl::Time now) noexcept {
   static absl::Time last_updated;
   auto delta_t = absl::ToDoubleSeconds(now - last_updated);
@@ -328,98 +196,6 @@ void CGroup<Reg>::cpu_peak_utilization_v2(absl::Time now) noexcept {
     cpu_user->Set((secs / avail_cpu_time) * 100);
   }
   prev_user_time = stats["user_usec"];
-}
-
-template <typename Reg>
-void CGroup<Reg>::kmem_stats_v1() noexcept {
-  static auto kmem_fail_cnt = registry_->GetMonotonicCounter("cgroup.kmem.failures");
-  static auto tcp_fail_cnt = registry_->GetMonotonicCounter("cgroup.kmem.tcpFailures");
-
-  // userspace and kernel memory are all counted against the same
-  // counters in v2, so there are no independent kmem metrics.
-
-  auto mem_fail = read_num_from_file(path_prefix_, "memory/memory.kmem.failcnt");
-  if (mem_fail >= 0) {
-    kmem_fail_cnt->Set(mem_fail);
-  }
-
-  auto tcp_mem_fail = read_num_from_file(path_prefix_, "memory/memory.kmem.tcp.failcnt");
-  if (tcp_mem_fail >= 0) {
-    tcp_fail_cnt->Set(tcp_mem_fail);
-  }
-
-  auto usage_bytes = read_num_from_file(path_prefix_, "memory/memory.kmem.usage_in_bytes");
-  if (usage_bytes >= 0) {
-    registry_->GetGauge("cgroup.kmem.used")->Set(usage_bytes);
-  }
-
-  auto limit_bytes = read_num_from_file(path_prefix_, "memory/memory.kmem.limit_in_bytes");
-  if (limit_bytes >= 0) {
-    registry_->GetGauge("cgroup.kmem.limit")->Set(limit_bytes);
-  }
-
-  auto max_usage_bytes = read_num_from_file(path_prefix_, "memory/memory.kmem.max_usage_in_bytes");
-  if (max_usage_bytes >= 0) {
-    registry_->GetGauge("cgroup.kmem.maxUsed")->Set(max_usage_bytes);
-  }
-
-  auto tcp_usage_bytes = read_num_from_file(path_prefix_, "memory/memory.kmem.tcp.usage_in_bytes");
-  if (tcp_usage_bytes >= 0) {
-    registry_->GetGauge("cgroup.kmem.tcpUsed")->Set(tcp_usage_bytes);
-  }
-
-  auto tcp_limit_bytes = read_num_from_file(path_prefix_, "memory/memory.kmem.tcp.limit_in_bytes");
-  if (tcp_limit_bytes >= 0) {
-    registry_->GetGauge("cgroup.kmem.tcpLimit")->Set(tcp_limit_bytes);
-  }
-
-  auto tcp_max_usage_bytes =
-      read_num_from_file(path_prefix_, "memory/memory.kmem.tcp.max_usage_in_bytes");
-  if (max_usage_bytes >= 0) {
-    registry_->GetGauge("cgroup.kmem.tcpMaxUsed")->Set(tcp_max_usage_bytes);
-  }
-}
-
-template <typename Reg>
-void CGroup<Reg>::memory_stats_v1() noexcept {
-  auto usage_bytes = read_num_from_file(path_prefix_, "memory/memory.usage_in_bytes");
-  if (usage_bytes >= 0) {
-    registry_->GetGauge("cgroup.mem.used")->Set(usage_bytes);
-  }
-
-  auto limit_bytes = read_num_from_file(path_prefix_, "memory/memory.limit_in_bytes");
-  if (limit_bytes >= 0) {
-    registry_->GetGauge("cgroup.mem.limit")->Set(limit_bytes);
-  }
-
-  static auto mem_fail_cnt = registry_->GetMonotonicCounter("cgroup.mem.failures");
-  auto mem_fail = read_num_from_file(path_prefix_, "memory/memory.failcnt");
-  if (mem_fail >= 0) {
-    mem_fail_cnt->Set(mem_fail);
-  }
-
-  kmem_stats_v1();
-
-  std::unordered_map<std::string, int64_t> stats;
-  parse_kv_from_file(path_prefix_, "memory/memory.stat", &stats);
-
-  static auto usage_cache_gauge = registry_->GetGauge("cgroup.mem.processUsage", {{"id", "cache"}});
-  usage_cache_gauge->Set(stats["total_cache"]);
-
-  static auto usage_rss_gauge = registry_->GetGauge("cgroup.mem.processUsage", {{"id", "rss"}});
-  usage_rss_gauge->Set(stats["total_rss"]);
-
-  static auto usage_rss_huge_gauge = registry_->GetGauge("cgroup.mem.processUsage", {{"id", "rss_huge"}});
-  usage_rss_huge_gauge->Set(stats["total_rss_huge"]);
-
-  static auto usage_mapped_file_gauge = registry_->GetGauge("cgroup.mem.processUsage", {{"id", "mapped_file"}});
-  usage_mapped_file_gauge->Set(stats["total_mapped_file"]);
-
-  static auto minor_page_faults = registry_->GetMonotonicCounter("cgroup.mem.pageFaults", {{"id", "minor"}});
-  minor_page_faults->Set(stats["total_pgfault"]);
-
-  static auto major_page_faults = registry_->GetMonotonicCounter("cgroup.mem.pageFaults", {{"id", "major"}});
-  major_page_faults->Set(stats["total_pgmajfault"]);
 }
 
 template <typename Reg>
@@ -467,48 +243,6 @@ void CGroup<Reg>::memory_stats_v2() noexcept {
 }
 
 template <typename Reg>
-void CGroup<Reg>::memory_stats_std_v1() noexcept {
-  auto mem_limit = read_num_from_file(path_prefix_, "memory/memory.limit_in_bytes");
-  auto mem_usage = read_num_from_file(path_prefix_, "memory/memory.usage_in_bytes");
-  auto memsw_limit = read_num_from_file(path_prefix_, "memory/memory.memsw.limit_in_bytes");
-  auto memsw_usage = read_num_from_file(path_prefix_, "memory/memory.memsw.usage_in_bytes");
-
-  std::unordered_map<std::string, int64_t> stats;
-  parse_kv_from_file(path_prefix_, "memory/memory.stat", &stats);
-
-  static auto cached = registry_->GetGauge("mem.cached");
-  auto cache = stats["total_cache"];
-  cached->Set(cache);
-
-  static auto shared = registry_->GetGauge("mem.shared");
-  auto shmem = stats["total_shmem"];
-  shared->Set(shmem);
-
-  auto swap = stats["total_swap"];
-
-  static auto avail_real = registry_->GetGauge("mem.availReal");
-  static auto free_real = registry_->GetGauge("mem.freeReal");
-  static auto total_real = registry_->GetGauge("mem.totalReal");
-  if (mem_limit >= 0 && mem_usage >= 0) {
-    avail_real->Set(mem_limit - mem_usage + cache);
-    free_real->Set(mem_limit - mem_usage);
-    total_real->Set(mem_limit);
-  }
-
-  static auto avail_swap = registry_->GetGauge("mem.availSwap");
-  static auto total_swap = registry_->GetGauge("mem.totalSwap");
-  if (memsw_limit >= 0 && mem_limit >= 0) {
-    avail_swap->Set(memsw_limit - mem_limit - swap);
-    total_swap->Set(memsw_limit - mem_limit);
-  }
-
-  static auto total_free = registry_->GetGauge("mem.totalFree");
-  if (memsw_limit >= 0 && memsw_usage >= 0) {
-    total_free->Set(memsw_limit - memsw_usage);
-  }
-}
-
-template <typename Reg>
 void CGroup<Reg>::memory_stats_std_v2() noexcept {
   auto mem_limit = read_num_from_file(path_prefix_, "memory.max");
   auto mem_usage = read_num_from_file(path_prefix_, "memory.current");
@@ -549,24 +283,6 @@ void CGroup<Reg>::memory_stats_std_v2() noexcept {
 }
 
 template <typename Reg>
-void CGroup<Reg>::cpu_throttle_v1() noexcept {
-  std::unordered_map<std::string, int64_t> stats;
-  parse_kv_from_file(path_prefix_, "cpuacct/cpu.stat", &stats);
-
-  static auto throttled_time = registry_->GetCounter("cgroup.cpu.throttledTime");
-  static auto prev_throttled_time = static_cast<int64_t>(-1);
-  auto cur_throttled_time = stats["throttled_time"];
-  if (prev_throttled_time >= 0) {
-    auto seconds = (cur_throttled_time - prev_throttled_time) / NANOS;
-    throttled_time->Add(seconds);
-  }
-  prev_throttled_time = cur_throttled_time;
-
-  static auto nr_throttled = registry_->GetMonotonicCounter("cgroup.cpu.numThrottled");
-  nr_throttled->Set(stats["nr_throttled"]);
-}
-
-template <typename Reg>
 void CGroup<Reg>::cpu_throttle_v2() noexcept {
   std::unordered_map<std::string, int64_t> stats;
   parse_kv_from_file(path_prefix_, "cpu.stat", &stats);
@@ -592,12 +308,6 @@ void CGroup<Reg>::do_cpu_stats(absl::Time now, bool is_cgroup2) noexcept {
     cpu_throttle_v2();
     cpu_usage_time_v2();
     cpu_utilization_v2(now);
-  } else {
-    cpu_processing_time_v1();
-    cpu_shares_v1(now);
-    cpu_throttle_v1();
-    cpu_usage_time_v1();
-    cpu_utilization_v1(now);
   }
 }
 
@@ -605,8 +315,6 @@ template <typename Reg>
 void CGroup<Reg>::do_cpu_peak_stats(absl::Time now, bool is_cgroup2) noexcept {
   if (is_cgroup2) {
     cpu_peak_utilization_v2(now);
-  } else {
-    cpu_peak_utilization_v1(now);
   }
 }
 


### PR DESCRIPTION
All Titus hosts are now running on Jammy with cgroupv2. This change keeps the cgroupv2 test and boolean flags, to ensure that data collection is valid, and as a hedge against the development of cgroupv3. Any instances that are not running with cgroupv2 with will not report any cgroup metrics.