### PR TITLE
do not set sys.time.estimatedError when time is unsynchronized

### DIFF
--- a/bin/atlas-agent.cc
+++ b/bin/atlas-agent.cc
@@ -309,7 +309,7 @@ int main(int argc, char* const argv[]) {
     nvidia_lib = std::make_unique<Nvml>();
     logger->info("Will attempt to collect GPU metrics");
   } catch (atlasagent::NvmlException& e) {
-    logger->info("Will not collect GPU metrics: %s", e.what());
+    logger->info("Will not collect GPU metrics: {}", e.what());
   }
 
   atlasagent::HttpClient<>::GlobalInit();

--- a/lib/ntp.h
+++ b/lib/ntp.h
@@ -51,7 +51,9 @@ class Ntp {
     }
 
     unsynchronized_->Set(err == TIME_ERROR);
-    estimatedError_->Set(time->esterror / 1e6);
+    if (err != TIME_ERROR) {
+      estimatedError_->Set(time->esterror / 1e6);
+    }
   }
 
   void chrony_stats(const std::string& tracking, const std::vector<std::string>& sources) noexcept {

--- a/lib/ntp_test.cc
+++ b/lib/ntp_test.cc
@@ -126,8 +126,7 @@ TEST(Ntp, adjtime_err) {
 
   auto ms = registry.Measurements();
   auto map = measurements_to_map(ms, "");
-  std::unordered_map<std::string, double> expected = {{"sys.time.unsynchronized|gauge", 1},
-                                                      {"sys.time.estimatedError|gauge", 0.2}};
+  std::unordered_map<std::string, double> expected = {{"sys.time.unsynchronized|gauge", 1}};
   EXPECT_EQ(map, expected);
 }
 }  // namespace

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -4,10 +4,10 @@ MAYBE_PYTHON=$(find /apps -maxdepth 1 -type l -name "python*")
 
 if [[ -n "$MAYBE_PYTHON" ]]; then
   PYTHON3="$MAYBE_PYTHON/bin/python3"
-  echo "using $MAYBE_PYTHON/bin/python3 ($(PYTHON3 -V))"
+  echo "using $PYTHON3 ($($PYTHON3 -V))"
 else
   PYTHON3="python3"
-  echo "using $(which python3) ($(PYTHON3 -V))"
+  echo "using $(which $PYTHON3) ($($PYTHON3 -V))"
 fi
 
 # create and activate virtualenv


### PR DESCRIPTION
We are trying to gather some data on the accuracy of clock time across the fleet, and the `sys.time.estimatedError` was reporting a number of 16s values.

These values occur when the kernel has not synchonized the clock yet. This fact is tracked with the `sys.time.unsynchronized` metric. The `estimatedError` metric should only have valid results from `ntp_adjtime`.