### PR TITLE
exclude /tmp/buildkit and /var/lib from disk metrics

### DIFF
--- a/lib/internal/disk.inc
+++ b/lib/internal/disk.inc
@@ -106,7 +106,9 @@ std::vector<MountPoint> Disk<Reg>::filter_interesting_mount_points(
         starts_with(mp.mount_point.c_str(), "/mnt/docker") ||
         starts_with(mp.mount_point.c_str(), "/proc") ||
         starts_with(mp.mount_point.c_str(), "/run") ||
-        starts_with(mp.mount_point.c_str(), "/sys")) {
+        starts_with(mp.mount_point.c_str(), "/sys") ||
+        starts_with(mp.mount_point.c_str(), "/tmp/buildkit") ||
+        starts_with(mp.mount_point.c_str(), "/var/lib")) {
       continue;
     }
 


### PR DESCRIPTION
The /tmp/buildkit pattern was generating over 60K id values per three hour period.

There are a few different /var/lib patterns that are generating a few hundred id
values per three-hour period.