### PR TITLE
reduce logging

### DIFF
--- a/bin/atlas-agent.cc
+++ b/bin/atlas-agent.cc
@@ -269,7 +269,7 @@ void collect_system_metrics(TaggingRegistry* registry, std::unique_ptr<atlasagen
         gpu->gpu_metrics();
       }
       auto elapsed = duration_cast<milliseconds>(system_clock::now() - start);
-      Logger()->info("Published system metrics (delay={})", elapsed);
+      Logger()->debug("Published system metrics (delay={})", elapsed);
       next_slow_run += seconds(60);
     }
 


### PR DESCRIPTION
As a general rule, we should not log repeated messages that are not actionable for the service - we should log initialization data, and messages that convey exceptional conditions, which indicate some action should be taken. Routine messages every minute for every instance contribute lots of useless log volume, which may be ingested into our logging systems.

The reason to keep things like this at debug level, is that in the event where we need more detailed information on operation while debugging, we can enable the --verbose flag and restart the service to see these messages, so we have ani easy way to restore them when needed.