### PR TITLE
Fix DCGM Percentile Based Metrics

### DIFF
--- a/lib/dcgm_stats.cc
+++ b/lib/dcgm_stats.cc
@@ -59,25 +59,25 @@ bool GpuMetricsDCGM<Reg>::update_metrics(std::map<int, std::vector<double>>& dat
       double value = data.at(i);
       switch (i) {
         case 0:
-          detail::gauge(registry_, "gpu.dcgm.graphicsEngineActivity", gpuId)->Set(value);
+          detail::gauge(registry_, "gpu.dcgm.graphicsEngineActivity", gpuId)->Set(value * DCGMConstants::PercentileConversion);
           break;
         case 1:
-          detail::gauge(registry_, "gpu.dcgm.sm", gpuId, "activity")->Set(value);
+          detail::gauge(registry_, "gpu.dcgm.sm", gpuId, "activity")->Set(value * DCGMConstants::PercentileConversion);
           break;
         case 2:
-          detail::gauge(registry_, "gpu.dcgm.sm", gpuId, "occupancy")->Set(value);
+          detail::gauge(registry_, "gpu.dcgm.sm", gpuId, "occupancy")->Set(value * DCGMConstants::PercentileConversion);
           break;
         case 3:
-          detail::gauge(registry_, "gpu.dcgm.tensorCoresUtilization", gpuId)->Set(value);
+          detail::gauge(registry_, "gpu.dcgm.tensorCoresUtilization", gpuId)->Set(value * DCGMConstants::PercentileConversion);
           break;
         case 4:
-          detail::gauge(registry_, "gpu.dcgm.memoryBandwidthUtilization", gpuId)->Set(value);
+          detail::gauge(registry_, "gpu.dcgm.memoryBandwidthUtilization", gpuId)->Set(value * DCGMConstants::PercentileConversion);
           break;
         case 5:
-          detail::gauge(registry_, "gpu.dcgm.pipeUtilization", gpuId, "fp32")->Set(value);
+          detail::gauge(registry_, "gpu.dcgm.pipeUtilization", gpuId, "fp32")->Set(value * DCGMConstants::PercentileConversion);
           break;
         case 6:
-          detail::gauge(registry_, "gpu.dcgm.pipeUtilization", gpuId, "fp16")->Set(value);
+          detail::gauge(registry_, "gpu.dcgm.pipeUtilization", gpuId, "fp16")->Set(value * DCGMConstants::PercentileConversion);
           break;
         case 7:
           detail::counter(registry_, "gpu.dcgm.pcie.bytes", gpuId, "out")->Add(value * DCGMConstants::BytesConversion);

--- a/lib/dcgm_stats.h
+++ b/lib/dcgm_stats.h
@@ -25,6 +25,9 @@ struct DCGMConstants {
   /* DCGMI reports bytes as bytes per second, multiply by this constant to
     ensure consistency with our Counters */
   static constexpr auto BytesConversion{60};
+  /* DCGMI reports percentiles as decimals so .93 is actually 93 percent
+    we need to multiply our values by this const*/
+  static constexpr auto PercentileConversion{100};
 };
 
 namespace detail {


### PR DESCRIPTION
DCGM reports percentile metrics as decimals. For example .93 reported by dcgm actually correlates to 93%. Thus we need to multiply these values by 100.