### PR TITLE
ignore /mnt/kubelet for disk metrics

### DIFF
--- a/lib/collectors/disk/src/disk.cpp
+++ b/lib/collectors/disk/src/disk.cpp
@@ -108,6 +108,7 @@ std::vector<MountPoint> Disk<Reg>::filter_interesting_mount_points(
 
     if (starts_with(mp.mount_point.c_str(), "/dev") ||
         starts_with(mp.mount_point.c_str(), "/mnt/docker") ||
+        starts_with(mp.mount_point.c_str(), "/mnt/kubelet") ||
         starts_with(mp.mount_point.c_str(), "/proc") ||
         starts_with(mp.mount_point.c_str(), "/run") ||
         starts_with(mp.mount_point.c_str(), "/sys") ||

--- a/lib/collectors/disk/src/disk.cpp
+++ b/lib/collectors/disk/src/disk.cpp
@@ -108,6 +108,7 @@ std::vector<MountPoint> Disk<Reg>::filter_interesting_mount_points(
 
     if (starts_with(mp.mount_point.c_str(), "/dev") ||
         starts_with(mp.mount_point.c_str(), "/mnt/docker") ||
+        starts_with(mp.mount_point.c_str(), "/mnt/jenkins") ||
         starts_with(mp.mount_point.c_str(), "/mnt/kubelet") ||
         starts_with(mp.mount_point.c_str(), "/proc") ||
         starts_with(mp.mount_point.c_str(), "/run") ||


### PR DESCRIPTION
We are seeing a bunch of these with values like:

```
mnt_kubelet_pods_{UUID}_volumes_kubernetes.io~empty-dir_dev-shm
```

Adding to the list to ignore similar to the docker mounts.