### PR TITLE
Fix CI Build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,9 @@ if [[ ! -d $BUILD_DIR ]]; then
   if [[ "$BUILD_TYPE" == "Debug" ]]; then
     conan install . --output-folder="$BUILD_DIR" --build="*" --settings=build_type="$BUILD_TYPE"
   else
-    conan install . --output-folder="$BUILD_DIR" --build=missing
+    # force m4 to build from source; pre-built binaries from Conan Center may
+    # be linked against a newer glibc than the build environment provides
+    conan install . --output-folder="$BUILD_DIR" --build=missing --build=m4/*
   fi
 
   echo -e "${BLUE}==== install source dependencies ====${NC}"


### PR DESCRIPTION
Fix m4 glibc incompatibility in bionic build container

Problem
The amd64 Newt CI build fails with autom4te: error: need GNU m4 1.4 or later when libcurl runs autoreconf.

Root Cause
A recent [m4 recipe update](https://github.com/conan-io/conan-center-index/commit/af3bbce7d46dbf1d0ced94f3fb9f98cae6f30bd7) in conan-center-index created a new recipe revision, invalidating cached pre-built binaries. The replacement binaries were compiled on a system with glibc 2.34, but our bionic build container has glibc 2.27. With --build=missing, Conan downloads these incompatible binaries instead of building from source, causing the m4 binary to fail at runtime.

Fix
Add --build=m4/* to force m4 to build from source in the container, producing a binary compatible with the local glibc.

Note
As bionic (EOL June 2023) falls further out of Conan Center's binary compatibility window, other packages may hit the same issue. Migrating to a jammy build image would be a more sustainable long-term fix.