### PR TITLE
Fix Perfspect Logs

### DIFF
--- a/lib/collectors/perfspect/src/perfspect.cpp
+++ b/lib/collectors/perfspect/src/perfspect.cpp
@@ -119,7 +119,7 @@ bool Perfspect::StartScript() try
     this->scriptProcess = std::make_unique<boost::process::child>(
         fullBinaryPath.string(), PerfspectConstants::command, PerfspectConstants::eventfileFlag, eventfilePath,
         PerfspectConstants::metricfileFlag, metricfilePath, PerfspectConstants::intervalFlag,
-        PerfspectConstants::intervalValue, PerfspectConstants::liveFlag, boost::process::std_out > *this->asyncPipe,
+        PerfspectConstants::intervalValue, PerfspectConstants::liveFlag, PerfspectConstants::syslogFlag, boost::process::std_out > *this->asyncPipe,
         boost::process::std_err > boost::process::null);
 
     // Start async reading

--- a/lib/collectors/perfspect/src/perfspect.h
+++ b/lib/collectors/perfspect/src/perfspect.h
@@ -23,6 +23,7 @@ struct PerfspectConstants
     static constexpr auto intervalFlag{"--interval"};
     static constexpr auto intervalValue{"5"};
     static constexpr auto liveFlag{"--live"};
+    static constexpr auto syslogFlag{"--syslog"};
     static constexpr auto metricFrequency{"cpu.perfspect.frequency"};
     static constexpr auto metricCycles{"cpu.perfspect.cycles"};
     static constexpr auto metricInstructions{"cpu.perfspect.instructions"};


### PR DESCRIPTION
Write Perfspect logs to syslog rather than /apps/atlas-system-agent/bin