### PR TITLE
service_monitor: support extra tags in .systemd-unit config files

### DIFF
--- a/lib/collectors/service_monitor/src/service_monitor.cpp
+++ b/lib/collectors/service_monitor/src/service_monitor.cpp
@@ -86,12 +86,13 @@ catch (const std::exception& e)
 
 template <typename T>
 bool ServiceMonitor::publish_metric(const std::string& service, std::optional<T> val, double scale,
-                                    std::string_view name, std::string_view scope, std::string_view errMsg) const
+                                    std::string_view name, std::string_view scope, const ExtraTags& extraTags,
+                                    std::string_view errMsg) const
 {
     if (val)
     {
-        auto g = scope.empty() ? detail::gauge(registry_, name, service)
-                               : detail::gaugeScoped(registry_, name, service, scope);
+        auto g = scope.empty() ? detail::gauge(registry_, name, service, extraTags)
+                               : detail::gaugeScoped(registry_, name, service, scope, extraTags);
         g.Set(static_cast<double>(*val) * scale);
         return true;
     }
@@ -104,13 +105,14 @@ bool ServiceMonitor::publish_metric(const std::string& service, std::optional<T>
 
 bool ServiceMonitor::collect_process_metrics(const std::string& service, const ServiceProperties& props,
                                              std::chrono::steady_clock::time_point now,
-                                             CpuRateTracker<unsigned int>& cpu) const
+                                             CpuRateTracker<unsigned int>& cpu,
+                                             const ExtraTags& extraTags) const
 {
     bool success = true;
     success &= publish_metric(service, get_rss(props.mainPid), static_cast<double>(pageSize_),
-                              ServiceMonitorConstants::RssName, "", "Failed to get RSS");
+                              ServiceMonitorConstants::RssName, "", extraTags, "Failed to get RSS");
     success &= publish_metric(service, get_number_fds(props.mainPid), 1.0, ServiceMonitorConstants::FdsName, "process",
-                              "Failed to get FD count");
+                              extraTags, "Failed to get FD count");
 
     // Read the main PID's accumulated CPU time. On a failed read there is no sample this cycle: skip
     // the tracker update so its baseline is preserved and the next good read spans the gap correctly.
@@ -126,19 +128,20 @@ bool ServiceMonitor::collect_process_metrics(const std::string& service, const S
     // The tracker keys on the PID, so a restart (new PID) resets the baseline rather than producing a
     // cross-generation delta. A missing percentage on the first cycle is normal, not a failure.
     publish_metric(service, cpu.update(props.mainPid, curr_us, now), 1.0, ServiceMonitorConstants::CpuUsageName,
-                   "process");
+                   "process", extraTags);
     return success;
 }
 
 bool ServiceMonitor::collect_cgroup_metrics(const std::string& service, const ServiceProperties& props,
                                             std::chrono::steady_clock::time_point now,
-                                            CpuRateTracker<std::string>& cpu) const
+                                            CpuRateTracker<std::string>& cpu,
+                                            const ExtraTags& extraTags) const
 {
     bool success = true;
     success &= publish_metric(service, get_cgroup_memory(props.controlGroup), 1.0, ServiceMonitorConstants::MemoryName,
-                              "", "Failed to get cgroup memory");
+                              "", extraTags, "Failed to get cgroup memory");
     success &= publish_metric(service, get_total_fds(props.controlGroup), 1.0, ServiceMonitorConstants::FdsName,
-                              "service", "Failed to get cgroup total FDs");
+                              "service", extraTags, "Failed to get cgroup total FDs");
 
     // As above: a failed read means no sample this cycle, so skip the tracker update.
     auto usage = get_cgroup_cpu_usage(props.controlGroup);
@@ -150,7 +153,7 @@ bool ServiceMonitor::collect_cgroup_metrics(const std::string& service, const Se
 
     // The tracker keys on the control-group path, so a recreated cgroup resets the baseline.
     publish_metric(service, cpu.update(props.controlGroup, *usage, now), 1.0, ServiceMonitorConstants::CpuUsageName,
-                   "service");
+                   "service", extraTags);
     return success;
 }
 
@@ -170,8 +173,11 @@ try
             continue;
         }
 
+        auto extraTags = read_service_extra_tags(service);
+
         const auto stateStr = fmt::format("{}.{}", props->activeState, props->subState);
-        detail::gaugeServiceState(registry_, ServiceMonitorConstants::ServiceStatusName, service, stateStr).Set(1);
+        detail::gaugeServiceState(registry_, ServiceMonitorConstants::ServiceStatusName, service, stateStr, extraTags)
+            .Set(1);
 
         if (props->activeState != ServiceMonitorUtilConstants::Active ||
             props->subState != ServiceMonitorUtilConstants::Running)
@@ -184,8 +190,8 @@ try
         // start invalid, so that cycle publishes no CPU%. The trackers are mutated in place -- there
         // is no per-cycle state object to rebuild and reassign.
         ServiceCpuState& state = cpuState_[service];
-        success &= collect_process_metrics(service, *props, now, state.process);
-        success &= collect_cgroup_metrics(service, *props, now, state.cgroup);
+        success &= collect_process_metrics(service, *props, now, state.process, extraTags);
+        success &= collect_cgroup_metrics(service, *props, now, state.cgroup, extraTags);
     }
 
     return success;

--- a/lib/collectors/service_monitor/src/service_monitor.h
+++ b/lib/collectors/service_monitor/src/service_monitor.h
@@ -38,27 +38,31 @@ namespace detail
 
 // Unscoped gauge: the metric name itself carries the distinction (e.g. RssName is always the main
 // PID, MemoryName is always the whole cgroup), so no scope tag is needed.
-inline auto gauge(Registry* registry, const std::string_view name, const std::string_view serviceName)
+inline auto gauge(Registry* registry, const std::string_view name, const std::string_view serviceName,
+                  const ExtraTags& extraTags = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)}};
+    tags.insert(extraTags.begin(), extraTags.end());
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 
 // Scoped gauge: the same metric name is published for both the main PID ("process") and the whole
 // cgroup ("service"); the scope tag tells them apart.
 inline auto gaugeScoped(Registry* registry, const std::string_view name, const std::string_view serviceName,
-                        const std::string_view scope)
+                        const std::string_view scope, const ExtraTags& extraTags = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)},
                                                              {"scope", fmt::format("{}", scope)}};
+    tags.insert(extraTags.begin(), extraTags.end());
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 
 inline auto gaugeServiceState(Registry* registry, const std::string_view name, const std::string_view serviceName,
-                              const std::string_view state)
+                              const std::string_view state, const ExtraTags& extraTags = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)}};
     tags.emplace("state", fmt::format("{}", state));
+    tags.insert(extraTags.begin(), extraTags.end());
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 }  // namespace detail
@@ -96,18 +100,20 @@ class ServiceMonitor
     // gauge; a non-empty scope adds the "scope" tag.
     template <typename T>
     bool publish_metric(const std::string& service, std::optional<T> val, double scale, std::string_view name,
-                        std::string_view scope, std::string_view errMsg = {}) const;
+                        std::string_view scope, const ExtraTags& extraTags, std::string_view errMsg = {}) const;
 
     // Publish the per-main-PID metrics (rss, process-scope fds, process-scope cpu) and advance the
     // process CPU tracker. Returns whether every metric this cycle was collected successfully. const:
     // the only mutated state is the caller-owned tracker passed by reference, not a member of this.
     bool collect_process_metrics(const std::string& service, const ServiceProperties& props,
-                                 std::chrono::steady_clock::time_point now, CpuRateTracker<unsigned int>& cpu) const;
+                                 std::chrono::steady_clock::time_point now, CpuRateTracker<unsigned int>& cpu,
+                                 const ExtraTags& extraTags) const;
     // Publish the whole-cgroup metrics (memory, summed fds, service-scope cpu) and advance the cgroup
     // CPU tracker. Returns whether every metric this cycle was collected successfully. const for the
     // same reason as collect_process_metrics.
     bool collect_cgroup_metrics(const std::string& service, const ServiceProperties& props,
-                                std::chrono::steady_clock::time_point now, CpuRateTracker<std::string>& cpu) const;
+                                std::chrono::steady_clock::time_point now, CpuRateTracker<std::string>& cpu,
+                                const ExtraTags& extraTags) const;
 
     Registry* registry_;
     std::vector<std::regex> config_;

--- a/lib/collectors/service_monitor/src/service_monitor_utils.cpp
+++ b/lib/collectors/service_monitor/src/service_monitor_utils.cpp
@@ -106,7 +106,7 @@ try
     std::vector<std::regex> regexPatterns{};
     for (const auto& regex_pattern : stringPatterns.value())
     {
-        if (regex_pattern.empty())
+        if (regex_pattern.empty() || regex_pattern.find('=') != std::string::npos)
         {
             continue;
         }
@@ -170,6 +170,45 @@ catch (const std::exception& e)
 {
     atlasagent::Logger()->error("Exception: {} in parse_service_monitor_config_directory", e.what());
     return std::nullopt;
+}
+
+// ── Extra tags ──────────────────────────────────────────────────────────────
+
+ExtraTags read_service_extra_tags(const std::string& serviceName)
+{
+    // Derive the config filename from the service name: strip ".service", look for the matching
+    // .systemd-unit file in conf.d/. Lines containing '=' are treated as key=value tags; lines
+    // without '=' are regex patterns (handled by parse_regex_config_file) and skipped here.
+    auto name = serviceName;
+    const std::string suffix = ".service";
+    if (name.size() > suffix.size() && name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0)
+    {
+        name.erase(name.size() - suffix.size());
+    }
+
+    auto configPath = std::filesystem::path(ServiceMonitorConstants::ConfigPath) / (name + ".systemd-unit");
+
+    ExtraTags tags;
+    auto lines = atlasagent::read_file(configPath.string().c_str());
+    if (!lines)
+    {
+        return tags;
+    }
+
+    for (const auto& line : lines.value())
+    {
+        if (line.empty())
+        {
+            continue;
+        }
+        auto pos = line.find('=');
+        if (pos == std::string::npos || pos == 0)
+        {
+            continue;
+        }
+        tags.emplace(line.substr(0, pos), line.substr(pos + 1));
+    }
+    return tags;
 }
 
 // ── Process (per-PID) helpers ────────────────────────────────────────────────

--- a/lib/collectors/service_monitor/src/service_monitor_utils.h
+++ b/lib/collectors/service_monitor/src/service_monitor_utils.h
@@ -37,6 +37,8 @@ struct DBusConstants
     static constexpr auto PropertyMainPID = "MainPID";
 };
 
+using ExtraTags = std::unordered_map<std::string, std::string>;
+
 struct ServiceMonitorUtilConstants
 {
     static constexpr auto ProcPath{"/proc"};
@@ -81,6 +83,9 @@ std::optional<ServiceProperties> get_service_properties(const std::string& servi
 
 // Config Parsing Functions
 std::optional<std::vector<std::regex>> parse_service_monitor_config_directory(const char* directoryPath);
+
+// Extra tag support: reads key=value lines from the service's .systemd-unit config file.
+ExtraTags read_service_extra_tags(const std::string& serviceName);
 
 // Process (per-PID) metric functions
 std::optional<unsigned long> get_rss(const unsigned int& pid);


### PR DESCRIPTION
Lines containing '=' in a .systemd-unit file are now parsed as key=value tags and added to all systemd.service.* gauges for the matched service. Lines without '=' continue to be treated as regex patterns. The regex parser skips '=' lines and '#' comment lines for backward compatibility.

Tags are re-read from the config file each collection cycle so they pick up changes from service restarts/redeployments.

Example proxyd.systemd-unit:
```
^foo\.service$
build.revision=1.71.0/RELEASE
```