### PR TITLE
service_monitor: add service.status tag from systemd StatusText

### DIFF
--- a/lib/collectors/service_monitor/src/service_monitor.cpp
+++ b/lib/collectors/service_monitor/src/service_monitor.cpp
@@ -105,12 +105,13 @@ catch (const std::exception& e)
 
 template <typename T>
 bool ServiceMonitor::publish_metric(const std::string& service, std::optional<T> val, double scale,
-                                    std::string_view name, std::string_view scope, std::string_view errMsg) const
+                                    std::string_view name, std::string_view scope, std::string_view status,
+                                    std::string_view errMsg) const
 {
     if (val)
     {
-        auto g = scope.empty() ? detail::gauge(registry_, name, service)
-                               : detail::gaugeScoped(registry_, name, service, scope);
+        auto g = scope.empty() ? detail::gauge(registry_, name, service, status)
+                               : detail::gaugeScoped(registry_, name, service, scope, status);
         g.Set(static_cast<double>(*val) * scale);
         return true;
     }
@@ -127,9 +128,9 @@ bool ServiceMonitor::collect_process_metrics(const std::string& service, const S
 {
     bool success = true;
     success &= publish_metric(service, get_rss(props.mainPid), static_cast<double>(pageSize_),
-                              ServiceMonitorConstants::RssName, "", "Failed to get RSS");
+                              ServiceMonitorConstants::RssName, "", props.statusText, "Failed to get RSS");
     success &= publish_metric(service, get_number_fds(props.mainPid), 1.0, ServiceMonitorConstants::FdsName, "process",
-                              "Failed to get FD count");
+                              props.statusText, "Failed to get FD count");
 
     // Read the main PID's accumulated CPU time. On a failed read there is no sample this cycle: skip
     // the tracker update so its baseline is preserved and the next good read spans the gap correctly.
@@ -145,7 +146,7 @@ bool ServiceMonitor::collect_process_metrics(const std::string& service, const S
     // The tracker keys on the PID, so a restart (new PID) resets the baseline rather than producing a
     // cross-generation delta. A missing percentage on the first cycle is normal, not a failure.
     publish_metric(service, cpu.update(props.mainPid, curr_us, now), 1.0, ServiceMonitorConstants::CpuUsageName,
-                   "process");
+                   "process", props.statusText);
     return success;
 }
 
@@ -155,9 +156,9 @@ bool ServiceMonitor::collect_cgroup_metrics(const std::string& service, const Se
 {
     bool success = true;
     success &= publish_metric(service, get_cgroup_memory(props.controlGroup), 1.0, ServiceMonitorConstants::MemoryName,
-                              "", "Failed to get cgroup memory");
+                              "", props.statusText, "Failed to get cgroup memory");
     success &= publish_metric(service, get_total_fds(props.controlGroup), 1.0, ServiceMonitorConstants::FdsName,
-                              "service", "Failed to get cgroup total FDs");
+                              "service", props.statusText, "Failed to get cgroup total FDs");
 
     // As above: a failed read means no sample this cycle, so skip the tracker update.
     auto usage = get_cgroup_cpu_usage(props.controlGroup);
@@ -169,7 +170,7 @@ bool ServiceMonitor::collect_cgroup_metrics(const std::string& service, const Se
 
     // The tracker keys on the control-group path, so a recreated cgroup resets the baseline.
     publish_metric(service, cpu.update(props.controlGroup, *usage, now), 1.0, ServiceMonitorConstants::CpuUsageName,
-                   "service");
+                   "service", props.statusText);
     return success;
 }
 
@@ -190,7 +191,9 @@ try
         }
 
         const auto stateStr = fmt::format("{}.{}", props->activeState, props->subState);
-        detail::gaugeServiceState(registry_, ServiceMonitorConstants::ServiceStatusName, service, stateStr).Set(1);
+        detail::gaugeServiceState(registry_, ServiceMonitorConstants::ServiceStatusName, service, stateStr,
+                                  props->statusText)
+            .Set(1);
 
         if (props->activeState != ServiceMonitorUtilConstants::Active ||
             props->subState != ServiceMonitorUtilConstants::Running)

--- a/lib/collectors/service_monitor/src/service_monitor.h
+++ b/lib/collectors/service_monitor/src/service_monitor.h
@@ -38,27 +38,39 @@ namespace detail
 
 // Unscoped gauge: the metric name itself carries the distinction (e.g. RssName is always the main
 // PID, MemoryName is always the whole cgroup), so no scope tag is needed.
-inline auto gauge(Registry* registry, const std::string_view name, const std::string_view serviceName)
+inline void maybeAddStatus(std::unordered_map<std::string, std::string>& tags, const std::string_view status)
+{
+    if (!status.empty())
+    {
+        tags.emplace("service.status", fmt::format("{}", status));
+    }
+}
+
+inline auto gauge(Registry* registry, const std::string_view name, const std::string_view serviceName,
+                  const std::string_view status = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)}};
+    maybeAddStatus(tags, status);
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 
 // Scoped gauge: the same metric name is published for both the main PID ("process") and the whole
 // cgroup ("service"); the scope tag tells them apart.
 inline auto gaugeScoped(Registry* registry, const std::string_view name, const std::string_view serviceName,
-                        const std::string_view scope)
+                        const std::string_view scope, const std::string_view status = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)},
                                                              {"scope", fmt::format("{}", scope)}};
+    maybeAddStatus(tags, status);
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 
 inline auto gaugeServiceState(Registry* registry, const std::string_view name, const std::string_view serviceName,
-                              const std::string_view state)
+                              const std::string_view state, const std::string_view status = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)}};
     tags.emplace("state", fmt::format("{}", state));
+    maybeAddStatus(tags, status);
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 }  // namespace detail
@@ -104,7 +116,7 @@ class ServiceMonitor
     // gauge; a non-empty scope adds the "scope" tag.
     template <typename T>
     bool publish_metric(const std::string& service, std::optional<T> val, double scale, std::string_view name,
-                        std::string_view scope, std::string_view errMsg = {}) const;
+                        std::string_view scope, std::string_view status, std::string_view errMsg = {}) const;
 
     // Publish the per-main-PID metrics (rss, process-scope fds, process-scope cpu) and advance the
     // process CPU tracker. Returns whether every metric this cycle was collected successfully. const:

--- a/lib/collectors/service_monitor/src/service_monitor_utils.cpp
+++ b/lib/collectors/service_monitor/src/service_monitor_utils.cpp
@@ -68,12 +68,19 @@ try
         .withArguments(DBusConstants::ServiceInterface, DBusConstants::PropertyControlGroup)
         .storeResultsTo(controlGroupVariant);
 
+    sdbus::Variant statusTextVariant;
+    proxy->callMethod(DBusConstants::MethodGet)
+        .onInterface(DBusConstants::PropertiesInterface)
+        .withArguments(DBusConstants::ServiceInterface, DBusConstants::PropertyStatusText)
+        .storeResultsTo(statusTextVariant);
+
     return ServiceProperties{
         serviceName,
         activeStateVariant.get<std::string>(),
         subStateVariant.get<std::string>(),
         mainPidVariant.get<uint32_t>(),
         controlGroupVariant.get<std::string>(),
+        statusTextVariant.get<std::string>(),
     };
 }
 catch (const sdbus::Error& e)

--- a/lib/collectors/service_monitor/src/service_monitor_utils.h
+++ b/lib/collectors/service_monitor/src/service_monitor_utils.h
@@ -35,6 +35,7 @@ struct DBusConstants
     // Service interface constants
     static constexpr auto ServiceInterface = "org.freedesktop.systemd1.Service";
     static constexpr auto PropertyMainPID = "MainPID";
+    static constexpr auto PropertyStatusText = "StatusText";
 };
 
 struct ServiceMonitorUtilConstants
@@ -73,6 +74,7 @@ struct ServiceProperties
     std::string subState;
     unsigned int mainPid;
     std::string controlGroup;
+    std::string statusText;
 };
 
 // DBus Functions


### PR DESCRIPTION
Read the StatusText D-Bus property (https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#STATUS=%E2%80%A6) alongside the existing MainPID/ControlGroup reads. When non-empty, emit it as a service.status tag on all systemd.service.* gauges.

Services set StatusText via `sd_notify("STATUS=<status>")`. The value is re-read every collection cycle, so any status updates are picked up without restarting atlas-system-agent.