### PR TITLE
Add K8s Flavor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        agent: [system, titus]
+        agent: [system, titus, k8s]
     steps:
       - uses: actions/checkout@v4
 
@@ -21,16 +21,8 @@ jobs:
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update && sudo apt-get install -y binutils-dev g++-15 libiberty-dev libdrm-dev
 
-      - name: Build atlas-system-agent
-        if: ${{ startsWith(matrix.agent, 'system') }}
+      - name: Build atlas-${{ matrix.agent }}-agent
         run: |
           ./setup-venv.sh
           source venv/bin/activate
-          TITUS_SYSTEM_SERVICE=OFF ./build.sh
-
-      - name: Build atlas-titus-agent
-        if: ${{ startsWith(matrix.agent, 'titus') }}
-        run: |
-          ./setup-venv.sh
-          source venv/bin/activate
-          TITUS_SYSTEM_SERVICE=ON ./build.sh
+          AGENT_FLAVOR=${{ matrix.agent }} ./build.sh

--- a/AtlasAgent/CMakeLists.txt
+++ b/AtlasAgent/CMakeLists.txt
@@ -1,9 +1,11 @@
 #-- atlas_system_agent executable
 # The entry point is shared; the per-flavor collection logic lives in a separate
-# source selected by TITUS_SYSTEM_SERVICE (see the top-level CMakeLists.txt), so
-# only one collector implementation is ever compiled into the binary.
-if(TITUS_SYSTEM_SERVICE)
+# source selected by AGENT_FLAVOR (see the top-level CMakeLists.txt), so only one
+# collector implementation is ever compiled into the binary.
+if(AGENT_FLAVOR STREQUAL "titus")
     set(ATLAS_AGENT_SOURCES src/atlas-agent.cpp src/titus-agent.cpp)
+elseif(AGENT_FLAVOR STREQUAL "k8s")
+    set(ATLAS_AGENT_SOURCES src/atlas-agent.cpp src/k8s-agent.cpp)
 else()
     set(ATLAS_AGENT_SOURCES src/atlas-agent.cpp src/system-agent.cpp)
 endif()

--- a/AtlasAgent/src/atlas-agent.cpp
+++ b/AtlasAgent/src/atlas-agent.cpp
@@ -1,8 +1,9 @@
-// Entry point for the Atlas agent. This file holds the pieces common to both
+// Entry point for the Atlas agent. This file holds the pieces common to all
 // build flavors — option parsing, signal handling, and the helpers shared by
 // the collector loops. The per-flavor collection logic lives in
-// system-agent.cpp / titus-agent.cpp (only one is compiled per build, selected
-// by TITUS_SYSTEM_SERVICE); the shared declarations live in atlas-agent.h.
+// system-agent.cpp / titus-agent.cpp / k8s-agent.cpp (only one is compiled per
+// build, selected by AGENT_FLAVOR); the shared declarations live in
+// atlas-agent.h.
 
 #include "atlas-agent.h"
 
@@ -168,8 +169,10 @@ int main(int argc, char* const argv[])
     argc -= idx;
     argv += idx;
 
-#if defined(TITUS_SYSTEM_SERVICE)
+#if defined(AGENT_FLAVOR_TITUS)
     const char* process = argc > 1 ? argv[1] : "atlas-titus-agent";
+#elif defined(AGENT_FLAVOR_K8S)
+    const char* process = argc > 1 ? argv[1] : "atlas-k8s-agent";
 #else
     const char* process = argc > 1 ? argv[1] : "atlas-system-agent";
 #endif
@@ -178,7 +181,7 @@ int main(int argc, char* const argv[])
     backward::SignalHandling sh;
 
     std::unordered_map<std::string, std::string> common_tags{{"xatlas.process", process}};
-#if defined(TITUS_SYSTEM_SERVICE)
+#if defined(AGENT_FLAVOR_TITUS)
     auto titus_host = std::getenv("TITUS_HOST_EC2_INSTANCE_ID");
     if (titus_host != nullptr && titus_host[0] != '\0')
     {
@@ -197,9 +200,12 @@ int main(int argc, char* const argv[])
 
     Config config(WriterConfig(WriterTypes::Unix), common_tags);
     Registry registry(config);
-#if defined(TITUS_SYSTEM_SERVICE)
+#if defined(AGENT_FLAVOR_TITUS)
     Logger()->info("Start gathering Titus system metrics");
     collect_titus_metrics(&registry, options.network_tags, options.max_monitored_services);
+#elif defined(AGENT_FLAVOR_K8S)
+    Logger()->info("Start gathering Kubernetes system metrics");
+    collect_k8s_metrics(&registry, options.network_tags, options.max_monitored_services);
 #else
     Logger()->info("Start gathering EC2 system metrics");
     collect_system_metrics(&registry, options.network_tags, options.max_monitored_services);

--- a/AtlasAgent/src/atlas-agent.h
+++ b/AtlasAgent/src/atlas-agent.h
@@ -1,9 +1,10 @@
 #pragma once
 
-// Declarations shared between the entry point (atlas-agent.cpp) and the two
-// mutually-exclusive collector implementations (system-agent.cpp and
-// titus-agent.cpp). Only one collector source is compiled per build, selected
-// by the TITUS_SYSTEM_SERVICE definition (see the top-level CMakeLists.txt).
+// Declarations shared between the entry point (atlas-agent.cpp) and the three
+// mutually-exclusive collector implementations (system-agent.cpp,
+// titus-agent.cpp, and k8s-agent.cpp). Only one collector source is compiled per
+// build, selected by AGENT_FLAVOR (system|titus|k8s), which maps to one of the
+// AGENT_FLAVOR_{SYSTEM,TITUS,K8S} defines (see the top-level CMakeLists.txt).
 
 #include <lib/collectors/nvml/src/gpumetrics.h>
 #include <lib/logger/src/logger.h>
@@ -57,9 +58,12 @@ extern terminator runner;
 // boundary. Shared by both collector loops.
 long initial_polling_delay();
 
-#if defined(TITUS_SYSTEM_SERVICE)
+#if defined(AGENT_FLAVOR_TITUS)
 void collect_titus_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,
                            const int& max_monitored_services);
+#elif defined(AGENT_FLAVOR_K8S)
+void collect_k8s_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,
+                         const int& max_monitored_services);
 #else
 void collect_system_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,
                             const int& max_monitored_services);

--- a/AtlasAgent/src/k8s-agent.cpp
+++ b/AtlasAgent/src/k8s-agent.cpp
@@ -3,11 +3,11 @@
 // and system-agent equivalents live in titus-agent.cpp / system-agent.cpp; shared
 // helpers are declared in atlas-agent.h.
 //
-// The k8s flavor currently mirrors the Titus (container) collector set exactly:
-// both are cgroup-v2 container-scoped agents. It intentionally reuses the shared
-// container-scoped collector methods (Proc::CollectTitus, Disk::titus_disk_stats)
-// until k8s resource semantics diverge from Atlas/Titus, at which point they can
-// be split into dedicated k8s methods.
+// The k8s flavor currently mirrors the Titus (container) collector set: both are
+// cgroup-v2 container-scoped agents. It uses dedicated k8s collection methods
+// (Proc::CollectK8s, Disk::k8s_disk_stats) that currently duplicate the Titus
+// logic, giving k8s its own place to diverge as its resource semantics differ
+// from Atlas/Titus.
 
 #include "atlas-agent.h"
 
@@ -41,8 +41,8 @@ static void gather_slow_k8s_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aws*
     cGroup->MemoryStatsV2();
     cGroup->MemoryStatsStdV2();
     cGroup->NetworkStats();
-    disk->titus_disk_stats();
-    proc->CollectTitus();
+    disk->k8s_disk_stats();
+    proc->CollectK8s();
 }
 
 void collect_k8s_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,

--- a/AtlasAgent/src/k8s-agent.cpp
+++ b/AtlasAgent/src/k8s-agent.cpp
@@ -1,7 +1,13 @@
-// Titus-agent metric collection. Compiled only when AGENT_FLAVOR=titus
-// (AGENT_FLAVOR_TITUS is defined; see AtlasAgent/CMakeLists.txt). The system-agent
-// and k8s-agent equivalents live in system-agent.cpp / k8s-agent.cpp; shared
+// Kubernetes-agent metric collection. Compiled only when AGENT_FLAVOR=k8s
+// (AGENT_FLAVOR_K8S is defined; see the top-level CMakeLists.txt). The titus-agent
+// and system-agent equivalents live in titus-agent.cpp / system-agent.cpp; shared
 // helpers are declared in atlas-agent.h.
+//
+// The k8s flavor currently mirrors the Titus (container) collector set exactly:
+// both are cgroup-v2 container-scoped agents. It intentionally reuses the shared
+// container-scoped collector methods (Proc::CollectTitus, Disk::titus_disk_stats)
+// until k8s resource semantics diverge from Atlas/Titus, at which point they can
+// be split into dedicated k8s methods.
 
 #include "atlas-agent.h"
 
@@ -24,12 +30,12 @@ using Disk = atlasagent::Disk;
 using PerfMetrics = atlasagent::PerfMetrics;
 using Proc = atlasagent::Proc;
 
-static void gather_peak_titus_metrics(CGroup* cGroup, const bool fiveSecondMetricsEnabled, const bool sixtySecondMetricsEnabled)
+static void gather_peak_k8s_metrics(CGroup* cGroup, const bool fiveSecondMetricsEnabled, const bool sixtySecondMetricsEnabled)
 {
     cGroup->CpuStats(fiveSecondMetricsEnabled, sixtySecondMetricsEnabled);
 }
 
-static void gather_slow_titus_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aws* aws)
+static void gather_slow_k8s_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aws* aws)
 {
     aws->collect();
     cGroup->MemoryStatsV2();
@@ -39,8 +45,8 @@ static void gather_slow_titus_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aw
     proc->CollectTitus();
 }
 
-void collect_titus_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,
-                           const int& max_monitored_services)
+void collect_k8s_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,
+                         const int& max_monitored_services)
 {
     using std::chrono::duration_cast;
     using std::chrono::milliseconds;
@@ -69,8 +75,8 @@ void collect_titus_metrics(Registry* registry, const std::unordered_map<std::str
 
     // the first call to this gather function takes ~100ms, so it must be
     // done before we start calculating times to wait for peak metrics
-    gather_slow_titus_metrics(&cGroup, &proc, &disk, &aws);
-    Logger()->info("Published slow Titus metrics (first iteration)");
+    gather_slow_k8s_metrics(&cGroup, &proc, &disk, &aws);
+    Logger()->info("Published slow Kubernetes metrics (first iteration)");
 
     auto now = system_clock::now();
     auto next_run = now;
@@ -86,7 +92,7 @@ void collect_titus_metrics(Registry* registry, const std::unordered_map<std::str
 
         // 1 second, 5 second, and 60 second CPU metrics are gathered here because they read from
         // the same /proc/stat file
-        gather_peak_titus_metrics(&cGroup, fiveSecondMetricsEnabled, sixtySecondMetricsEnabled);
+        gather_peak_k8s_metrics(&cGroup, fiveSecondMetricsEnabled, sixtySecondMetricsEnabled);
 
         // If its time to gather 5 second metrics, update the next run time
         // Currently we only have CPU metrics that run every 5 seconds, but if we add more in the future
@@ -100,12 +106,12 @@ void collect_titus_metrics(Registry* registry, const std::unordered_map<std::str
         // If its time to gather 60 second metrics, gather the metrics and update the next run time
         if (sixtySecondMetricsEnabled == true)
         {
-            gather_slow_titus_metrics(&cGroup, &proc, &disk, &aws);
+            gather_slow_k8s_metrics(&cGroup, &proc, &disk, &aws);
             perf_metrics.collect();
             GpuMetrics::Collect(gpu);
             ServiceMonitor::Collect(serviceMetrics);
             auto elapsed = duration_cast<milliseconds>(system_clock::now() - start);
-            Logger()->info("Published Titus metrics (delay={})", elapsed);
+            Logger()->info("Published Kubernetes metrics (delay={})", elapsed);
             next_sixty_second_run += seconds(60);
         }
 

--- a/AtlasAgent/src/system-agent.cpp
+++ b/AtlasAgent/src/system-agent.cpp
@@ -1,6 +1,7 @@
-// System-agent metric collection. Compiled only when TITUS_SYSTEM_SERVICE is
-// NOT defined (see AtlasAgent/CMakeLists.txt). The titus-agent equivalent lives
-// in titus-agent.cpp; shared helpers are declared in atlas-agent.h.
+// System-agent metric collection. Compiled only when AGENT_FLAVOR=system
+// (the default; see AtlasAgent/CMakeLists.txt). The titus-agent and k8s-agent
+// equivalents live in titus-agent.cpp / k8s-agent.cpp; shared helpers are
+// declared in atlas-agent.h.
 
 #include "atlas-agent.h"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,22 @@ find_package(sdbus-c++ REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(ZLIB REQUIRED)
 
-option(TITUS_SYSTEM_SERVICE "Titus System Service" OFF)
-if(TITUS_SYSTEM_SERVICE)
+# Agent build flavor. Exactly one of the three mutually-exclusive collector
+# implementations is compiled, selected by this value and mapped to a per-flavor
+# preprocessor define. See AtlasAgent/CMakeLists.txt for the source selection.
+set(AGENT_FLAVOR "system" CACHE STRING "Agent flavor: system, titus, or k8s")
+set_property(CACHE AGENT_FLAVOR PROPERTY STRINGS system titus k8s)
+if(AGENT_FLAVOR STREQUAL "titus")
     message(STATUS "building atlas-titus-agent")
-    add_definitions(-DTITUS_SYSTEM_SERVICE)
-else()
+    add_definitions(-DAGENT_FLAVOR_TITUS)
+elseif(AGENT_FLAVOR STREQUAL "k8s")
+    message(STATUS "building atlas-k8s-agent")
+    add_definitions(-DAGENT_FLAVOR_K8S)
+elseif(AGENT_FLAVOR STREQUAL "system")
     message(STATUS "building atlas-system-agent")
+    add_definitions(-DAGENT_FLAVOR_SYSTEM)
+else()
+    message(FATAL_ERROR "Invalid AGENT_FLAVOR '${AGENT_FLAVOR}'; must be system, titus, or k8s")
 endif()
 
 add_subdirectory(thirdparty/spectator-cpp)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# Atlas System Agent / Atlas Titus Agent
+# Atlas System Agent / Atlas Titus Agent / Atlas K8s Agent
 
 [![Build](https://github.com/Netflix-Skunkworks/atlas-system-agent/actions/workflows/build.yml/badge.svg)](https://github.com/Netflix-Skunkworks/atlas-system-agent/actions/workflows/build.yml)
 
-An agent that reports metrics for EC2 instances or [Titus] containers.
+An agent that reports metrics for EC2 instances, [Titus] containers, or
+[Kubernetes] containers.
+
+The build produces one of three mutually-exclusive flavors, selected at compile
+time via the `AGENT_FLAVOR` environment variable (`system` (default), `titus`, or
+`k8s`) consumed by `build.sh`.
 
 [Titus]: https://github.com/Netflix/titus/
+[Kubernetes]: https://kubernetes.io/
 
 ## Local & IDE Configuration
 
@@ -21,6 +27,10 @@ sudo apt install pkg-config
 source venv/bin/activate
 
 ./build.sh  # [clean|clean --confirm|skiptest]
+
+# build a specific flavor (default is system)
+AGENT_FLAVOR=titus ./build.sh
+AGENT_FLAVOR=k8s ./build.sh
 ```
 
 * Install the Conan plugin for CLion.

--- a/build.sh
+++ b/build.sh
@@ -76,10 +76,14 @@ if [[ $OSTYPE == "darwin"* ]]; then
 fi
 
 echo -e "${BLUE}==== generate build files ====${NC}"
-if [[ "$TITUS_SYSTEM_SERVICE" != "ON" ]]; then
-  TITUS_SYSTEM_SERVICE=OFF
+if [[ -z "$AGENT_FLAVOR" ]]; then
+  AGENT_FLAVOR=system
 fi
-cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DTITUS_SYSTEM_SERVICE="$TITUS_SYSTEM_SERVICE"
+if [[ "$AGENT_FLAVOR" != "system" && "$AGENT_FLAVOR" != "titus" && "$AGENT_FLAVOR" != "k8s" ]]; then
+  echo -e "${RED}ERROR: AGENT_FLAVOR must be system, titus, or k8s (got '$AGENT_FLAVOR')${NC}"
+  exit 1
+fi
+cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DAGENT_FLAVOR="$AGENT_FLAVOR"
 
 echo -e "${BLUE}==== build ====${NC}"
 cmake --build .

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -10,6 +10,10 @@ if [[ -z "$BUILD_TYPE" ]]; then
   BUILD_TYPE="Debug"
 fi
 
+if [[ -z "$AGENT_FLAVOR" ]]; then
+  AGENT_FLAVOR="system"
+fi
+
 # Build image if it does not exist
 if [[ -z "$(docker images -q $IMAGE_NAME 2>/dev/null)" ]]; then
   echo "Docker image $IMAGE_NAME not found. Building..."
@@ -22,7 +26,7 @@ docker rm $CONTAINER_NAME 2>/dev/null || true
 ## Run the container and execute build.sh inside the virtual environment
 docker run --name $CONTAINER_NAME \
   --entrypoint bash $IMAGE_NAME -lc \
-    "source /home/ubuntu/atlas-agent/venv/bin/activate && set -x && BUILD_TYPE=$BUILD_TYPE bash /home/ubuntu/atlas-agent/build.sh"
+    "source /home/ubuntu/atlas-agent/venv/bin/activate && set -x && BUILD_TYPE=$BUILD_TYPE AGENT_FLAVOR=$AGENT_FLAVOR bash /home/ubuntu/atlas-agent/build.sh"
 
 ## Copy the build output from the container to the host
 docker cp $CONTAINER_NAME:$CONTAINER_FILE_PATH $HOST_FILE_PATH

--- a/lib/collectors/disk/src/disk.cpp
+++ b/lib/collectors/disk/src/disk.cpp
@@ -304,6 +304,13 @@ void Disk::titus_disk_stats() noexcept
     stats_for_interesting_mps([](Disk* disk, const MountPoint& mp) { disk->update_stats_for(mp); });
 }
 
+// Currently a copy of titus_disk_stats(): the k8s flavor is container-scoped like Titus. Kept as a
+// separate entry point so k8s disk metrics can diverge from Titus without touching titus_disk_stats().
+void Disk::k8s_disk_stats() noexcept
+{
+    stats_for_interesting_mps([](Disk* disk, const MountPoint& mp) { disk->update_stats_for(mp); });
+}
+
 void Disk::update_stats_for(const MountPoint& mp) noexcept
 {
     struct statvfs st;

--- a/lib/collectors/disk/src/disk.cpp
+++ b/lib/collectors/disk/src/disk.cpp
@@ -43,8 +43,8 @@ std::vector<MountPoint> Disk::get_mount_points() const noexcept
 {
     auto unwanted_filesystems = get_nodev_filesystems(path_prefix_);
     unwanted_filesystems.erase("tmpfs");
-#if defined(TITUS_SYSTEM_SERVICE)
-    // for titus we generate metrics for overlay fs
+#if defined(AGENT_FLAVOR_TITUS) || defined(AGENT_FLAVOR_K8S)
+    // for titus and k8s (both container flavors) we generate metrics for overlay fs
     // see overlay_stats()
     unwanted_filesystems.erase("overlay");
 #endif

--- a/lib/collectors/disk/src/disk.h
+++ b/lib/collectors/disk/src/disk.h
@@ -52,6 +52,7 @@ class Disk
     {
     }
     void titus_disk_stats() noexcept;
+    void k8s_disk_stats() noexcept;
     void disk_stats() noexcept;
     void set_prefix(const std::string& new_prefix) noexcept;  // for testing
    private:

--- a/lib/collectors/proc/src/proc.cpp
+++ b/lib/collectors/proc/src/proc.cpp
@@ -758,6 +758,17 @@ void Proc::CollectTitus() noexcept
     uptime_stats();
 }
 
+// Currently a copy of CollectTitus(): the k8s flavor is container-scoped like Titus. Kept as a
+// separate entry point so k8s proc metrics can diverge from Titus without touching CollectTitus().
+void Proc::CollectK8s() noexcept
+{
+    netstat_stats();
+    network_stats();
+    process_stats();
+    snmp_stats();
+    uptime_stats();
+}
+
 void Proc::CpuStats(const bool fiveSecondMetrics, const bool sixtySecondMetricsEnabled) noexcept
 {
     auto cpuLines = ParseProcStatFile();

--- a/lib/collectors/proc/src/proc.h
+++ b/lib/collectors/proc/src/proc.h
@@ -17,6 +17,7 @@ class Proc
     // the individual per-metric collectors below are internal.
     void CollectSystem() noexcept;
     void CollectTitus() noexcept;
+    void CollectK8s() noexcept;
 
     // Peak CPU metrics run every second (1s/5s/60s cadence), separate from the slow set above.
     void CpuStats(const bool fiveSecondMetrics, const bool sixtySecondMetricsEnabled) noexcept;


### PR DESCRIPTION
## Context
Container workloads are migrating from Titus to Kubernetes. The agent already ships two mutually-exclusive flavors — `atlas-system-agent` (EC2 hosts) and `atlas-titus-agent` (Titus containers). This adds a third **k8s** flavor, and to
make three-way selection clean, replaces the boolean `TITUS_SYSTEM_SERVICE` build flag with an `AGENT_FLAVOR` selector.

## Build-flag cutover (breaking)
- `-DTITUS_SYSTEM_SERVICE=ON/OFF` → `-DAGENT_FLAVOR=system|titus|k8s` (default `system`), mapped to per-flavor defines `AGENT_FLAVOR_{SYSTEM,TITUS,K8S}`; an unknown value fails configuration.
- Every `#if defined(TITUS_SYSTEM_SERVICE) / #else` is now an explicit `#if / #elif / #else`, so no flavor silently inherits another's behavior (prototype in atlas-agent.h, process name + dispatch in atlas-agent.cpp, overlayfs handling in disk.cpp).
- `build.sh` / `docker-build.sh` take (and validate/forward) `AGENT_FLAVOR`; the CI matrix now builds system, titus, and k8s.
- **Breaking:** the old flag is removed — callers must pass `AGENT_FLAVOR=titus` instead of `TITUS_SYSTEM_SERVICE=ON`.

## New k8s flavor
- New `AtlasAgent/src/k8s-agent.cpp` (`collect_k8s_metrics`) → `atlas-k8s-agent`. It mirrors the Titus container collector set (cgroup-v2 cpu/mem/io/net, the
  Proc network subset, disk, perf, nvml GPU, ServiceMonitor) since both are cgroup-v2 container-scoped agents.
- Dedicated `Proc::CollectK8s()` and `Disk::k8s_disk_stats()` — currently copies of the Titus methods — give k8s its own entry points to diverge from as k8s cgroup semantics differ from Atlas/Titus.
- overlayfs disk metrics are enabled for k8s (like Titus).
- Host-identity tagging is intentionally deferred: process name only, no extra tags yet (the `titus.host` env tag stays titus-only).

## Testing
- All three flavors configure and compile; CI matrix (system/titus/k8s) is green.
- An invalid `AGENT_FLAVOR` fails configuration fast.

## Follow-ups (out of scope)
- k8s host/pod identity tags via the downward API.
- Divergence of k8s cgroup cpu/memory formulas from Atlas semantics.
- ServiceMonitor's `/sys/fs/cgroup/<ControlGroup>` assumption in containers.
