### PR TITLE
Bump SDBus Dep

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,7 @@ class AtlasSystemAgentConan(ConanFile):
         "libcurl/8.10.1",
         "openssl/3.3.2",
         "rapidjson/cci.20230929",
-        "sdbus-cpp/2.0.0",
+        "sdbus-cpp/2.3.1",
         "spdlog/1.15.0",
         "zlib/1.3.1",
     )

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,6 +25,8 @@ class AtlasSystemAgentConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
+        # Pin the libsystemd pulled in transitively by sdbus-cpp
+        self.requires("libsystemd/255.10", override=True)
         # TODO: remove this when SystemD updates package for zstd
         self.requires("zstd/1.5.7", override=True)
         # TODO: remove this when SystemD updates package for xz_utils


### PR DESCRIPTION
Bump sdbus-cpp to the latest version and override its libsystemd dependency from the default 255.2 to 255.10. libsystemd 255.2's filesystem table predates PID_FS_MAGIC, so it fails to configure against the newer kernel headers on the Rocky build agent; 255.10 backports the fix.