### PR TITLE
Update K8 Titus System

### DIFF
--- a/AtlasAgent/src/atlas-agent.cpp
+++ b/AtlasAgent/src/atlas-agent.cpp
@@ -59,7 +59,7 @@ long initial_polling_delay()
     std::random_device rdev;
     std::mt19937 generator(rdev());
 
-    // calculate previous step boundary using integer arithmetic, to determine start second
+    // Calculate previous step boundary using integer arithmetic, to determine start second
     auto now = std::chrono::system_clock::now();
     auto now_epoch = now.time_since_epoch();
     auto epoch = std::chrono::duration_cast<std::chrono::seconds>(now_epoch);
@@ -73,16 +73,13 @@ long initial_polling_delay()
         std::uniform_int_distribution<long> start_delay_dist(10 - start_second, 50 - start_second);
         return start_delay_dist(generator);
     }
-    else if (start_second > 50)
+    if (start_second > 50)
     {
         auto next_min = 60 - start_second;
         std::uniform_int_distribution<long> start_delay_dist(10, 50);
         return next_min + start_delay_dist(generator);
     }
-    else
-    {
-        return 0;
-    }
+    return 0;
 }
 
 struct agent_options

--- a/AtlasAgent/src/k8s-agent.cpp
+++ b/AtlasAgent/src/k8s-agent.cpp
@@ -48,11 +48,6 @@ static void gather_slow_k8s_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aws*
 void collect_k8s_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,
                          const int& max_monitored_services)
 {
-    using std::chrono::duration_cast;
-    using std::chrono::milliseconds;
-    using std::chrono::seconds;
-    using std::chrono::system_clock;
-
     Aws aws{registry};
     CGroup cGroup{registry};
     Disk disk{registry, ""};
@@ -60,33 +55,30 @@ void collect_k8s_metrics(Registry* registry, const std::unordered_map<std::strin
     Proc proc{registry, std::move(net_tags)};
 
     auto gpu = GpuMetrics::Create(registry);
-
-    // TODO: DCGM & ServiceMonitor have Dynamic metric collection. During each iteration we have to
-    // check if these optionals have a set value. lets improve how we handle this
     auto serviceMetrics = ServiceMonitor::Create(registry, max_monitored_services);
 
-    // initial polling delay, to prevent publishing too close to a minute boundary
+    // Initial polling delay, to prevent publishing too close to a minute boundary
     auto delay = initial_polling_delay();
     Logger()->info("Initial polling delay is {}s", delay);
     if (delay > 0)
     {
-        runner.wait_for(seconds(delay));
+        runner.wait_for(std::chrono::seconds(delay));
     }
 
-    // the first call to this gather function takes ~100ms, so it must be
+    // The first call to this gather function takes ~100ms, so it must be
     // done before we start calculating times to wait for peak metrics
     gather_slow_k8s_metrics(&cGroup, &proc, &disk, &aws);
     Logger()->info("Published slow Kubernetes metrics (first iteration)");
 
-    auto now = system_clock::now();
+    auto now = std::chrono::system_clock::now();
     auto next_run = now;
-    auto next_sixty_second_run = now + seconds(60);
-    auto next_five_second_run = now + seconds(5);
+    auto next_sixty_second_run = now + std::chrono::seconds(60);
+    auto next_five_second_run = now + std::chrono::seconds(5);
     std::chrono::nanoseconds time_to_sleep;
 
     do
     {
-        auto start = system_clock::now();
+        auto start = std::chrono::system_clock::now();
         bool fiveSecondMetricsEnabled = (start >= next_five_second_run);
         bool sixtySecondMetricsEnabled = (start >= next_sixty_second_run);
 
@@ -100,7 +92,7 @@ void collect_k8s_metrics(Registry* registry, const std::unordered_map<std::strin
         if (fiveSecondMetricsEnabled == true)
         {
             cGroup.IOStats();
-            next_five_second_run += seconds(5);
+            next_five_second_run += std::chrono::seconds(5);
         }
 
         // If its time to gather 60 second metrics, gather the metrics and update the next run time
@@ -110,12 +102,13 @@ void collect_k8s_metrics(Registry* registry, const std::unordered_map<std::strin
             perf_metrics.collect();
             GpuMetrics::Collect(gpu);
             ServiceMonitor::Collect(serviceMetrics);
-            auto elapsed = duration_cast<milliseconds>(system_clock::now() - start);
+            auto elapsed =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start);
             Logger()->info("Published Kubernetes metrics (delay={})", elapsed);
-            next_sixty_second_run += seconds(60);
+            next_sixty_second_run += std::chrono::seconds(60);
         }
 
-        next_run += seconds(1);
-        time_to_sleep = next_run - system_clock::now();
+        next_run += std::chrono::seconds(1);
+        time_to_sleep = next_run - std::chrono::system_clock::now();
     } while (runner.wait_for(time_to_sleep));
 }

--- a/AtlasAgent/src/system-agent.cpp
+++ b/AtlasAgent/src/system-agent.cpp
@@ -27,24 +27,17 @@
 #include <unordered_set>
 #include <vector>
 
-using Aws = atlasagent::Aws;
-using CpuFreq = atlasagent::CpuFreq;
-using Disk = atlasagent::Disk;
-using Ethtool = atlasagent::Ethtool;
-using Ntp = atlasagent::Ntp<>;
-using PerfMetrics = atlasagent::PerfMetrics;
-using PressureStall = atlasagent::PressureStall;
-using Proc = atlasagent::Proc;
-
-static void gather_peak_system_metrics(Proc* proc, const bool fiveSecondMetricsEnabled, const bool sixtySecondMetricsEnabled)
+static void gather_peak_system_metrics(atlasagent::Proc* proc, const bool fiveSecondMetricsEnabled,
+                                       const bool sixtySecondMetricsEnabled)
 {
     proc->CpuStats(fiveSecondMetricsEnabled, sixtySecondMetricsEnabled);
 }
 
-static void gather_scaling_metrics(CpuFreq* cpufreq) { cpufreq->Stats(); }
+static void gather_scaling_metrics(atlasagent::CpuFreq* cpufreq) { cpufreq->Stats(); }
 
-static void gather_slow_system_metrics(Proc* proc, Disk* disk, Ethtool* ethtool, Ntp* ntp, PressureStall* pressureStall,
-                                       Aws* aws)
+static void gather_slow_system_metrics(atlasagent::Proc* proc, atlasagent::Disk* disk, atlasagent::Ethtool* ethtool,
+                                       atlasagent::Ntp<>* ntp, atlasagent::PressureStall* pressureStall,
+                                       atlasagent::Aws* aws)
 {
     aws->collect();
     disk->disk_stats();
@@ -57,53 +50,44 @@ static void gather_slow_system_metrics(Proc* proc, Disk* disk, Ethtool* ethtool,
 void collect_system_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,
                             const int& max_monitored_services)
 {
-    using std::chrono::duration_cast;
-    using std::chrono::milliseconds;
-    using std::chrono::seconds;
-    using std::chrono::system_clock;
-
-    Aws aws{registry};
-    CpuFreq cpufreq{registry};
-    Disk disk{registry, ""};
-    Ethtool ethtool{registry, net_tags};
-    Ntp ntp{registry};
-    PerfMetrics perf_metrics{registry, ""};
-    PressureStall pressureStall{registry};
-    Proc proc{registry, net_tags};
+    atlasagent::Aws aws{registry};
+    atlasagent::CpuFreq cpufreq{registry};
+    atlasagent::Disk disk{registry, ""};
+    atlasagent::Ethtool ethtool{registry, net_tags};
+    atlasagent::Ntp<> ntp{registry};
+    atlasagent::PerfMetrics perf_metrics{registry, ""};
+    atlasagent::PressureStall pressureStall{registry};
+    atlasagent::Proc proc{registry, net_tags};
 
     auto gpu = GpuMetrics::Create(registry);
-
-    // TODO: DCGM, EBS, and ServiceMonitor have Dynamic metric collection. During each iteration we have to
-    // check if these optionals have a set value. lets improve how we handle this
-    // Each collector's availability check + logging lives in its own Create() factory.
     auto gpuDCGM = GpuMetricsDCGM::Create(registry);
     auto serviceMetrics = ServiceMonitor::Create(registry, max_monitored_services);
     auto perfspectMetrics = Perfspect::Create(registry);
     auto ebsMetrics = EBSCollector::Create(registry);
     auto gpuAMD = atlasagent::GpuMetricsAMD::Create(registry);
 
-    // initial polling delay, to prevent publishing too close to a minute boundary
+    // Initial polling delay, to prevent publishing too close to a minute boundary
     auto delay = initial_polling_delay();
     Logger()->info("Initial polling delay is {}s", delay);
     if (delay > 0)
     {
-        runner.wait_for(seconds(delay));
+        runner.wait_for(std::chrono::seconds(delay));
     }
 
-    // the first call to this gather function takes ~100ms, so it must be
+    // The first call to this gather function takes ~100ms, so it must be
     // done before we start calculating times to wait for peak metrics
     gather_slow_system_metrics(&proc, &disk, &ethtool, &ntp, &pressureStall, &aws);
     Logger()->info("Published slow system metrics (first iteration)");
 
-    auto now = system_clock::now();
+    auto now = std::chrono::system_clock::now();
     auto next_run = now;
-    auto next_sixty_second_run = now + seconds(60);
-    auto next_five_second_run = now + seconds(5);
+    auto next_sixty_second_run = now + std::chrono::seconds(60);
+    auto next_five_second_run = now + std::chrono::seconds(5);
     std::chrono::nanoseconds time_to_sleep;
 
     do
     {
-        auto start = system_clock::now();
+        auto start = std::chrono::system_clock::now();
         bool fiveSecondMetricsEnabled = (start >= next_five_second_run);
         bool sixtySecondMetricsEnabled = (start >= next_sixty_second_run);
 
@@ -118,7 +102,7 @@ void collect_system_metrics(Registry* registry, const std::unordered_map<std::st
         {
             Logger()->debug("Gathering 5 second metrics");
             Perfspect::Collect(perfspectMetrics);
-            next_five_second_run += seconds(5);
+            next_five_second_run += std::chrono::seconds(5);
         }
 
         // If it's time to gather the 60 second metrics
@@ -134,12 +118,13 @@ void collect_system_metrics(Registry* registry, const std::unordered_map<std::st
             EBSCollector::Collect(ebsMetrics);
             ServiceMonitor::Collect(serviceMetrics);
 
-            auto elapsed = duration_cast<milliseconds>(system_clock::now() - start);
+            auto elapsed =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start);
             Logger()->debug("Published system metrics (delay={})", elapsed);
-            next_sixty_second_run += seconds(60);
+            next_sixty_second_run += std::chrono::seconds(60);
         }
 
-        next_run += seconds(1);
-        time_to_sleep = next_run - system_clock::now();
+        next_run += std::chrono::seconds(1);
+        time_to_sleep = next_run - std::chrono::system_clock::now();
     } while (runner.wait_for(time_to_sleep));
 }

--- a/AtlasAgent/src/titus-agent.cpp
+++ b/AtlasAgent/src/titus-agent.cpp
@@ -18,18 +18,14 @@
 #include <regex>
 #include <vector>
 
-using Aws = atlasagent::Aws;
-using CGroup = atlasagent::CGroup;
-using Disk = atlasagent::Disk;
-using PerfMetrics = atlasagent::PerfMetrics;
-using Proc = atlasagent::Proc;
-
-static void gather_peak_titus_metrics(CGroup* cGroup, const bool fiveSecondMetricsEnabled, const bool sixtySecondMetricsEnabled)
+static void gather_peak_titus_metrics(atlasagent::CGroup* cGroup, const bool fiveSecondMetricsEnabled,
+                                      const bool sixtySecondMetricsEnabled)
 {
     cGroup->CpuStats(fiveSecondMetricsEnabled, sixtySecondMetricsEnabled);
 }
 
-static void gather_slow_titus_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aws* aws)
+static void gather_slow_titus_metrics(atlasagent::CGroup* cGroup, atlasagent::Proc* proc, atlasagent::Disk* disk,
+                                      atlasagent::Aws* aws)
 {
     aws->collect();
     cGroup->MemoryStatsV2();
@@ -42,21 +38,13 @@ static void gather_slow_titus_metrics(CGroup* cGroup, Proc* proc, Disk* disk, Aw
 void collect_titus_metrics(Registry* registry, const std::unordered_map<std::string, std::string>& net_tags,
                            const int& max_monitored_services)
 {
-    using std::chrono::duration_cast;
-    using std::chrono::milliseconds;
-    using std::chrono::seconds;
-    using std::chrono::system_clock;
-
-    Aws aws{registry};
-    CGroup cGroup{registry};
-    Disk disk{registry, ""};
-    PerfMetrics perf_metrics{registry, ""};
-    Proc proc{registry, std::move(net_tags)};
+    atlasagent::Aws aws{registry};
+    atlasagent::CGroup cGroup{registry};
+    atlasagent::Disk disk{registry, ""};
+    atlasagent::PerfMetrics perf_metrics{registry, ""};
+    atlasagent::Proc proc{registry, std::move(net_tags)};
 
     auto gpu = GpuMetrics::Create(registry);
-
-    // TODO: DCGM & ServiceMonitor have Dynamic metric collection. During each iteration we have to
-    // check if these optionals have a set value. lets improve how we handle this
     auto serviceMetrics = ServiceMonitor::Create(registry, max_monitored_services);
 
     // initial polling delay, to prevent publishing too close to a minute boundary
@@ -64,7 +52,7 @@ void collect_titus_metrics(Registry* registry, const std::unordered_map<std::str
     Logger()->info("Initial polling delay is {}s", delay);
     if (delay > 0)
     {
-        runner.wait_for(seconds(delay));
+        runner.wait_for(std::chrono::seconds(delay));
     }
 
     // the first call to this gather function takes ~100ms, so it must be
@@ -72,15 +60,15 @@ void collect_titus_metrics(Registry* registry, const std::unordered_map<std::str
     gather_slow_titus_metrics(&cGroup, &proc, &disk, &aws);
     Logger()->info("Published slow Titus metrics (first iteration)");
 
-    auto now = system_clock::now();
+    auto now = std::chrono::system_clock::now();
     auto next_run = now;
-    auto next_sixty_second_run = now + seconds(60);
-    auto next_five_second_run = now + seconds(5);
+    auto next_sixty_second_run = now + std::chrono::seconds(60);
+    auto next_five_second_run = now + std::chrono::seconds(5);
     std::chrono::nanoseconds time_to_sleep;
 
     do
     {
-        auto start = system_clock::now();
+        auto start = std::chrono::system_clock::now();
         bool fiveSecondMetricsEnabled = (start >= next_five_second_run);
         bool sixtySecondMetricsEnabled = (start >= next_sixty_second_run);
 
@@ -94,7 +82,7 @@ void collect_titus_metrics(Registry* registry, const std::unordered_map<std::str
         if (fiveSecondMetricsEnabled == true)
         {
             cGroup.IOStats();
-            next_five_second_run += seconds(5);
+            next_five_second_run += std::chrono::seconds(5);
         }
 
         // If its time to gather 60 second metrics, gather the metrics and update the next run time
@@ -104,12 +92,13 @@ void collect_titus_metrics(Registry* registry, const std::unordered_map<std::str
             perf_metrics.collect();
             GpuMetrics::Collect(gpu);
             ServiceMonitor::Collect(serviceMetrics);
-            auto elapsed = duration_cast<milliseconds>(system_clock::now() - start);
+            auto elapsed =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start);
             Logger()->info("Published Titus metrics (delay={})", elapsed);
-            next_sixty_second_run += seconds(60);
+            next_sixty_second_run += std::chrono::seconds(60);
         }
 
-        next_run += seconds(1);
-        time_to_sleep = next_run - system_clock::now();
+        next_run += std::chrono::seconds(1);
+        time_to_sleep = next_run - std::chrono::system_clock::now();
     } while (runner.wait_for(time_to_sleep));
 }


### PR DESCRIPTION
Clean up the entry points for the Titus, K8, and System agent. Also remove the unecessary `using` locaions for namespaces