### PR TITLE
Add StatusText To Service Monitoring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update && sudo apt-get install -y binutils-dev g++-15 libiberty-dev libdrm-dev
+          sudo apt-get update && sudo apt-get install -y binutils-dev g++-15 libiberty-dev
 
       - name: Build atlas-${{ matrix.agent }}-agent
         run: |

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,13 +15,14 @@ class AtlasSystemAgentConan(ConanFile):
         "fmt/11.0.2",
         "gtest/1.15.0",
         "libcurl/8.10.1",
+        "libdrm/2.4.124",
         "openssl/3.3.2",
         "rapidjson/cci.20230929",
         "sdbus-cpp/2.3.1",
         "spdlog/1.15.0",
         "zlib/1.3.1",
     )
-    tool_requires = ()
+    tool_requires = ("pkgconf/2.5.1",)
     generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):

--- a/lib/collectors/service_monitor/src/service_monitor.cpp
+++ b/lib/collectors/service_monitor/src/service_monitor.cpp
@@ -20,25 +20,6 @@ ServiceMonitor::ServiceMonitor(Registry* registry, std::vector<std::regex> confi
     }
 }
 
-std::optional<ServiceMonitor> ServiceMonitor::Create(Registry* registry, unsigned int max_services)
-{
-    auto config = parse_service_monitor_config_directory(ServiceMonitorConstants::ConfigPath);
-    if (!config.has_value())
-    {
-        atlasagent::Logger()->info("Service Monitoring is disabled.");
-        return std::nullopt;
-    }
-    return std::optional<ServiceMonitor>{std::in_place, registry, std::move(config.value()), max_services};
-}
-
-void ServiceMonitor::Collect(std::optional<ServiceMonitor>& self)
-{
-    if (self.has_value() && self->gather_metrics() == false)
-    {
-        atlasagent::Logger()->error("Failed to gather Service metrics");
-    }
-}
-
 bool ServiceMonitor::init_monitored_services()
 try
 {
@@ -105,12 +86,13 @@ catch (const std::exception& e)
 
 template <typename T>
 bool ServiceMonitor::publish_metric(const std::string& service, std::optional<T> val, double scale,
-                                    std::string_view name, std::string_view scope, std::string_view errMsg) const
+                                    std::string_view name, std::string_view scope, std::string_view status,
+                                    std::string_view errMsg) const
 {
     if (val)
     {
-        auto g = scope.empty() ? detail::gauge(registry_, name, service)
-                               : detail::gaugeScoped(registry_, name, service, scope);
+        auto g = scope.empty() ? detail::gauge(registry_, name, service, status)
+                               : detail::gaugeScoped(registry_, name, service, scope, status);
         g.Set(static_cast<double>(*val) * scale);
         return true;
     }
@@ -127,9 +109,9 @@ bool ServiceMonitor::collect_process_metrics(const std::string& service, const S
 {
     bool success = true;
     success &= publish_metric(service, get_rss(props.mainPid), static_cast<double>(pageSize_),
-                              ServiceMonitorConstants::RssName, "", "Failed to get RSS");
+                              ServiceMonitorConstants::RssName, "", props.statusText, "Failed to get RSS");
     success &= publish_metric(service, get_number_fds(props.mainPid), 1.0, ServiceMonitorConstants::FdsName, "process",
-                              "Failed to get FD count");
+                              props.statusText, "Failed to get FD count");
 
     // Read the main PID's accumulated CPU time. On a failed read there is no sample this cycle: skip
     // the tracker update so its baseline is preserved and the next good read spans the gap correctly.
@@ -145,7 +127,7 @@ bool ServiceMonitor::collect_process_metrics(const std::string& service, const S
     // The tracker keys on the PID, so a restart (new PID) resets the baseline rather than producing a
     // cross-generation delta. A missing percentage on the first cycle is normal, not a failure.
     publish_metric(service, cpu.update(props.mainPid, curr_us, now), 1.0, ServiceMonitorConstants::CpuUsageName,
-                   "process");
+                   "process", props.statusText);
     return success;
 }
 
@@ -155,9 +137,9 @@ bool ServiceMonitor::collect_cgroup_metrics(const std::string& service, const Se
 {
     bool success = true;
     success &= publish_metric(service, get_cgroup_memory(props.controlGroup), 1.0, ServiceMonitorConstants::MemoryName,
-                              "", "Failed to get cgroup memory");
+                              "", props.statusText, "Failed to get cgroup memory");
     success &= publish_metric(service, get_total_fds(props.controlGroup), 1.0, ServiceMonitorConstants::FdsName,
-                              "service", "Failed to get cgroup total FDs");
+                              "service", props.statusText, "Failed to get cgroup total FDs");
 
     // As above: a failed read means no sample this cycle, so skip the tracker update.
     auto usage = get_cgroup_cpu_usage(props.controlGroup);
@@ -169,7 +151,7 @@ bool ServiceMonitor::collect_cgroup_metrics(const std::string& service, const Se
 
     // The tracker keys on the control-group path, so a recreated cgroup resets the baseline.
     publish_metric(service, cpu.update(props.controlGroup, *usage, now), 1.0, ServiceMonitorConstants::CpuUsageName,
-                   "service");
+                   "service", props.statusText);
     return success;
 }
 
@@ -190,7 +172,9 @@ try
         }
 
         const auto stateStr = fmt::format("{}.{}", props->activeState, props->subState);
-        detail::gaugeServiceState(registry_, ServiceMonitorConstants::ServiceStatusName, service, stateStr).Set(1);
+        detail::gaugeServiceState(registry_, ServiceMonitorConstants::ServiceStatusName, service, stateStr,
+                                  props->statusText)
+            .Set(1);
 
         if (props->activeState != ServiceMonitorUtilConstants::Active ||
             props->subState != ServiceMonitorUtilConstants::Running)

--- a/lib/collectors/service_monitor/src/service_monitor.h
+++ b/lib/collectors/service_monitor/src/service_monitor.h
@@ -38,27 +38,39 @@ namespace detail
 
 // Unscoped gauge: the metric name itself carries the distinction (e.g. RssName is always the main
 // PID, MemoryName is always the whole cgroup), so no scope tag is needed.
-inline auto gauge(Registry* registry, const std::string_view name, const std::string_view serviceName)
+inline void maybeAddStatus(std::unordered_map<std::string, std::string>& tags, const std::string_view status)
+{
+    if (!status.empty())
+    {
+        tags.emplace("service.status", fmt::format("{}", status));
+    }
+}
+
+inline auto gauge(Registry* registry, const std::string_view name, const std::string_view serviceName,
+                  const std::string_view status = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)}};
+    maybeAddStatus(tags, status);
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 
 // Scoped gauge: the same metric name is published for both the main PID ("process") and the whole
 // cgroup ("service"); the scope tag tells them apart.
 inline auto gaugeScoped(Registry* registry, const std::string_view name, const std::string_view serviceName,
-                        const std::string_view scope)
+                        const std::string_view scope, const std::string_view status = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)},
                                                              {"scope", fmt::format("{}", scope)}};
+    maybeAddStatus(tags, status);
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 
 inline auto gaugeServiceState(Registry* registry, const std::string_view name, const std::string_view serviceName,
-                              const std::string_view state)
+                              const std::string_view state, const std::string_view status = {})
 {
     auto tags = std::unordered_map<std::string, std::string>{{"service.name", fmt::format("{}", serviceName)}};
     tags.emplace("state", fmt::format("{}", state));
+    maybeAddStatus(tags, status);
     return registry->CreateGauge(std::string(name), tags, ServiceMonitorConstants::GaugeTTLSeconds);
 }
 }  // namespace detail
@@ -85,14 +97,6 @@ class ServiceMonitor
 
     bool gather_metrics();
 
-    // Availability-aware factory: builds a monitor only when a valid config directory is found (logging
-    // when monitoring is disabled), otherwise returns nullopt.
-    static std::optional<ServiceMonitor> Create(Registry* registry, unsigned int max_services);
-
-    // Gathers metrics from `self` only when present; a no-op when disabled, logging on gather failure.
-    // The mirror of Create(): it owns the has_value() guard so callers don't repeat it.
-    static void Collect(std::optional<ServiceMonitor>& self);
-
    private:
     bool init_monitored_services();
     bool update_metrics();
@@ -104,7 +108,7 @@ class ServiceMonitor
     // gauge; a non-empty scope adds the "scope" tag.
     template <typename T>
     bool publish_metric(const std::string& service, std::optional<T> val, double scale, std::string_view name,
-                        std::string_view scope, std::string_view errMsg = {}) const;
+                        std::string_view scope, std::string_view status, std::string_view errMsg = {}) const;
 
     // Publish the per-main-PID metrics (rss, process-scope fds, process-scope cpu) and advance the
     // process CPU tracker. Returns whether every metric this cycle was collected successfully. const:

--- a/lib/collectors/service_monitor/src/service_monitor_utils.cpp
+++ b/lib/collectors/service_monitor/src/service_monitor_utils.cpp
@@ -68,12 +68,19 @@ try
         .withArguments(DBusConstants::ServiceInterface, DBusConstants::PropertyControlGroup)
         .storeResultsTo(controlGroupVariant);
 
+    sdbus::Variant statusTextVariant;
+    proxy->callMethod(DBusConstants::MethodGet)
+        .onInterface(DBusConstants::PropertiesInterface)
+        .withArguments(DBusConstants::ServiceInterface, DBusConstants::PropertyStatusText)
+        .storeResultsTo(statusTextVariant);
+
     return ServiceProperties{
         serviceName,
         activeStateVariant.get<std::string>(),
         subStateVariant.get<std::string>(),
         mainPidVariant.get<uint32_t>(),
         controlGroupVariant.get<std::string>(),
+        statusTextVariant.get<std::string>(),
     };
 }
 catch (const sdbus::Error& e)

--- a/lib/collectors/service_monitor/src/service_monitor_utils.h
+++ b/lib/collectors/service_monitor/src/service_monitor_utils.h
@@ -35,6 +35,7 @@ struct DBusConstants
     // Service interface constants
     static constexpr auto ServiceInterface = "org.freedesktop.systemd1.Service";
     static constexpr auto PropertyMainPID = "MainPID";
+    static constexpr auto PropertyStatusText = "StatusText";
 };
 
 struct ServiceMonitorUtilConstants
@@ -73,6 +74,7 @@ struct ServiceProperties
     std::string subState;
     unsigned int mainPid;
     std::string controlGroup;
+    std::string statusText;
 };
 
 // DBus Functions


### PR DESCRIPTION
Reads systemd's StatusText property from the D-Bus Service interface alongside the existing MainPID/ControlGroup lookups, and emits it as a service.status tag on every systemd.service.* gauge. The tag is omitted entirely when StatusText is empty, and the value is re-read each collection cycle so changes from restarts and hot-swaps are picked up without restarting the agent (Important for Services like Proxyd).